### PR TITLE
add simple tests and timing code

### DIFF
--- a/test/test_docs_content.py
+++ b/test/test_docs_content.py
@@ -1,32 +1,13 @@
-# test_basics.py
+# test_docs_content.py
 # David Prager Branner
+# 20140924
 
-
+"""Run tests mostly matching those in docstrings."""
 
 import bidict as B
 import pytest
 import random
 import string
-
-def random_ints(cardinality=10, hi=10, lo=-10):
-    """return list of `cardinality` ints, each in range (lo, hi)."""
-    if cardinality > hi - lo:
-        raise Exception(
-                'cardinality ({}) > hi - lo ({}); impossible condition'.
-                format(cardinality, hi-lo))
-    results = set()
-    while len(results) < cardinality:
-        results.add( random.randint(lo, hi))
-    return results
-
-def random_strings(length=10, cardinality=10):
-    """return list of `cardinality` strings, each length `length`."""
-    results = set()
-    while len(results) < cardinality:
-        results.add(''.join(
-                random.choice(string.ascii_letters + string.digits) 
-                for i in range(length)))
-    return results
 
 def test_basic_getitem():
     element_by_symbol = B.bidict(H='hydrogen')

--- a/test/test_large_lists.py
+++ b/test/test_large_lists.py
@@ -1,0 +1,57 @@
+# test_large_lists.py
+# David Prager Branner
+# 20140925
+
+"""Supply tests with large lists of randomly constructed items."""
+
+import bidict as B
+import pytest
+import random
+import string
+
+def random_ints(cardinality=10, hi=10, lo=-10):
+    """return list of `cardinality` ints, each in range (lo, hi)."""
+    if cardinality > hi - lo:
+        raise Exception(
+                'cardinality ({}) > hi - lo ({}); impossible condition'.
+                format(cardinality, hi-lo))
+    results = set()
+    while len(results) < cardinality:
+        results.add( random.randint(lo, hi))
+    return list(results)
+
+def random_strings(length=10, cardinality=10):
+    """return list of `cardinality` strings, each length `length`."""
+    results = set()
+    while len(results) < cardinality:
+        results.add(''.join(
+                random.choice(string.ascii_letters + string.digits)
+                for i in range(length)))
+    return list(results)
+
+hi_lo = 10000000
+card = 100000
+ints_to_strs = [(i) for i in zip(
+    random_ints(card, hi_lo, -hi_lo),
+    random_strings(10, card))]
+strs_to_ints = [(i) for i in zip(
+    random_strings(10, card),
+    random_ints(card, hi_lo, -hi_lo))]
+
+def test_inverse_01(lst=ints_to_strs):
+    assert lst == list(B.inverted(B.inverted(lst)))
+
+def test_inverse_02(lst=strs_to_ints):
+    assert lst == list(B.inverted(B.inverted(lst)))
+
+def test_get_item_01(lst=ints_to_strs):
+    b = B.bidict(lst)
+    for i in range(card//1000):
+        r = random.choice(list(b.keys()))
+        assert r == b[:b[r]]
+
+def test_get_item_02(lst=strs_to_ints):
+    b = B.bidict(lst)
+    for i in range(card//1000):
+        r = random.choice(list(b.keys()))
+        assert r == b[:b[r]]

--- a/timing/time_manual_reverse_dict.py
+++ b/timing/time_manual_reverse_dict.py
@@ -1,0 +1,77 @@
+#! /usr/bin/env python
+# time_manual_reverse_dict.py
+# David Prager Branner
+# 20140925
+
+import bidict as B
+import time
+import random
+import string
+
+
+def main(trials=10, card=100000, hi_lo = 10000000):
+    # Example with int: str
+    total_time_bidict = 0
+    total_time_revdict = 0
+    for i in range(trials):
+        start_time = time.time()
+        ints_to_strs = construct_ints_to_strs(card, hi_lo)
+        b = B.bidict(ints_to_strs)
+        total_time_bidict += time.time() - start_time
+        start_time = time.time()
+        rev = {v: k for k, v in ints_to_strs}
+        total_time_revdict += time.time() - start_time
+    print('Example with int: str.')
+    print('''In {} trials, average time for a list of cardinality {}:\n'''
+            '''    bidict:        {:.4f} sec.\n'''
+            '''    reversed dict: {:.4f} sec.'''.
+            format(trials, card, total_time_bidict/trials,
+                total_time_revdict/trials))
+    # Example with str: int
+    total_time_bidict = 0
+    total_time_revdict = 0
+    for i in range(trials):
+        start_time = time.time()
+        strs_to_ints = construct_strs_to_ints(card, hi_lo)
+        b = B.bidict(strs_to_ints)
+        total_time_bidict += time.time() - start_time
+        start_time = time.time()
+        rev = {v: k for k, v in ints_to_strs}
+        total_time_revdict += time.time() - start_time
+    print('\nExample with str: int.')
+    print('''In {} trials, average time for a list of cardinality {}:\n'''
+            '''    bidict:        {:.4f} sec.\n'''
+            '''    reversed dict: {:.4f} sec.'''.
+            format(trials, card, total_time_bidict/trials,
+                total_time_revdict/trials))
+
+def construct_ints_to_strs(card, hi_lo):
+    return [(i) for i in zip(
+            random_ints(card, hi_lo, -hi_lo),
+                random_strings(10, card))]
+
+def construct_strs_to_ints(card, hi_lo):
+    return [(i) for i in zip(
+            random_strings(10, card),
+                random_ints(card, hi_lo, -hi_lo))]
+
+def random_ints(cardinality=10, hi=10, lo=-10):
+    """return list of `cardinality` ints, each in range (lo, hi)."""
+    if cardinality > hi - lo:
+        raise Exception(
+                'cardinality ({}) > hi - lo ({}); impossible condition'.
+                format(cardinality, hi-lo))
+    results = set()
+    while len(results) < cardinality:
+        results.add( random.randint(lo, hi))
+    return list(results)
+
+def random_strings(length=10, cardinality=10):
+    """return list of `cardinality` strings, each length `length`."""
+    results = set()
+    while len(results) < cardinality:
+        results.add(''.join(
+                random.choice(string.ascii_letters + string.digits)
+                for i in range(length)))
+    return list(results)
+


### PR DESCRIPTION
The tests here may not be much use to you, but typing them out was useful to me in examining the library's workings. There are two files, meant for use with `pytest`:
- `test_docs_content.py` reproduces most of the tests in the docstrings.
- `test_large_lists.py` creates some large lists and tests `inverse` and `get_item` on their instantiations as `bidict`s.

The little timing program shows me how much slower `bidict` is than just creating a reversed dictionary. Of course, creation happens only once, and after that there are considerable savings in space and functionality. I am not suggesting any changes to `bidict` on account of this — I just wanted to see the difference in timing.

``` python
>>> import time_manual_reverse_dict as M
>>> M.main(200)
Example with int: str.
In 200 trials, average time for a list of cardinality 100000:
    bidict:        1.8498 sec.
    reversed dict: 0.0349 sec.

Example with str: int.
In 200 trials, average time for a list of cardinality 100000:
    bidict:        1.8675 sec.
    reversed dict: 0.0378 sec.
>>>
```
