### PR TITLE
add failing tests demonstrating None-slice issue

### DIFF
--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -67,10 +67,13 @@ def test_inv_identity(d):
 nan = float('nan')
 WORKAROUND_NAN_BUG = (nan, nan) != (nan, nan)
 
-@pytest.mark.xfail(WORKAROUND_NAN_BUG, reason='python with nan bug detected')
 @given(d)
 def test_equality(d):
+    if WORKAROUND_NAN_BUG:
+        assume(nan not in d)
     i = inv(d)
+    if WORKAROUND_NAN_BUG:
+        assume(nan not in i)
     b = bidict(d)
     assert b == d
     assert ~b == i

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -12,7 +12,7 @@ def b():
 single_test_data = {'H', 'hydrogen', -1, 0, 1}
 bad_start_values = single_test_data - {'H'}
 bad_stop_values = single_test_data - {'hydrogen'}
-pair_test_data = product(single_test_data, single_test_data)
+pair_test_data = set(product(single_test_data, repeat=2))
 
 
 def test_good_start(b):
@@ -47,3 +47,30 @@ def test_step(b, step):
 def test_empty(b):
     with pytest.raises(TypeError):
         b[::]
+
+
+# see ../docs/caveat-none-slice.rst.inc or
+# https://bidict.readthedocs.org/en/master/caveats.html#none-breaks-the-slice-syntax
+@pytest.fixture
+def b_none():
+    return bidict({'key': None, None: 'val'})
+
+@pytest.mark.xfail(raises=TypeError)
+def test_none_slice_fwd(b_none):
+    assert b_none[None:] == 'val'
+
+@pytest.mark.xfail(raises=TypeError)
+def test_none_slice_inv(b_none):
+    assert b_none[:None] == 'key'
+
+@pytest.mark.xfail(raises=TypeError)
+def test_none_slice_fwd_inv(b_none):
+    assert b_none[None:] + b_none[:None] == 'valkey'
+
+@pytest.mark.xfail(raises=TypeError)
+def test_list_w_none_slice_fwd(b_none):
+    assert ['foo'][0:][0] + b_none[None:] == 'fooval'
+
+@pytest.mark.xfail(raises=TypeError)
+def test_list_w_none_slice_inv(b_none):
+    assert ['foo'][0:][0] + b_none[:None] == 'fookey'


### PR DESCRIPTION
Hey @tomviner, this adds some `xfail` tests to your test_slice.py demonstrating the [none-slice](https://bidict.readthedocs.org/en/master/caveats.html#none-breaks-the-slice-syntax) issue. If a fix for that ever surfaces the `xfail`s could just get taken out. Think this looks ok to merge? Thanks!