### PR TITLE
several improvements to test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,49 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "pypy"
-  - "pypy3"
+
+matrix:
+  include:
+    - python: "2.7"
+      env:
+        - PYENV_PYTHON_VER=2.7.11
+        - PYENV_ROOT="$HOME/.pyenv"
+    - python: "3.3"
+      env:
+        - PYENV_PYTHON_VER=3.3.6
+        - PYENV_ROOT="$HOME/.pyenv"
+    - python: "3.4"
+      env:
+        - PYENV_PYTHON_VER=3.4.3
+        - PYENV_ROOT="$HOME/.pyenv"
+    - python: "3.5"
+      env:
+        - PYENV_PYTHON_VER=3.5.1
+        - PYENV_ROOT="$HOME/.pyenv"
+    - python: "pypy"
+      env:
+        - PYENV_PYTHON_VER=pypy-4.0.1
+        - PYENV_ROOT="$HOME/.pyenv"
 
 install:
-  - pip install -e .[test]
-  - pip install coveralls
-  - pip install tox-travis
+  # based on https://github.com/frol/flask-restplus-server-example/blob/018f48e5/.travis.yml
+  - |
+      if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
+        pushd "$PYENV_ROOT" && git pull && popd
+      else
+        rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
+      fi
+      "$PYENV_ROOT/bin/pyenv" install --skip-existing "$PYENV_PYTHON_VER"
+      virtualenv --python="$PYENV_ROOT/versions/$PYENV_PYTHON_VER/bin/python" "$HOME/virtualenvs/$PYENV_PYTHON_VER"
+      source "$HOME/virtualenvs/$PYENV_PYTHON_VER/bin/activate"
+  - travis_retry pip install -e .[test]
+  - travis_retry pip install coveralls
 
 script:
-  - python setup.py test
-  - pep257 bidict
+  - ./test.sh
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.pyenv
 
 after_success:
   coveralls

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,9 @@ Changelog
   :class:`bidict.frozenorderedbidict`.
 - Adopt `Open Code of Conduct
   <http://todogroup.org/opencodeofconduct/#bidict/jab@math.brown.edu>`_.
+- Drop official support for pypy3
+  (it still may work but is no longer being tested).
+  bidict may add back support for pypy3 once it's made more progress.
 
 0.10.0.post1 (2015-12-23)
 -------------------------

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,5 @@ testpaths = bidict tests docs
 ; need to collect doctests from files ending in .rst, .rst.inc, and .txt,
 ; but doctest-glob option is not multi-allowed. resort to including "doctest"
 ; in the filenames of all doctest files we want collected, and match on that.
-addopts = --doctest-modules --doctest-glob=*doctest* --ignore=docs/conf.py --ignore=setup.py --ignore=docs/_build --cov=bidict
+addopts = --doctest-modules --doctest-glob=*doctest* --ignore=docs/conf.py --ignore=setup.py --ignore=docs/_build
 doctest_optionflags = IGNORE_EXCEPTION_DETAIL ELLIPSIS

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from io import open
-from setuptools import setup, Command
+from setuptools import setup
 from warnings import warn
 
 try:
@@ -18,22 +18,14 @@ except Exception as e:
          '(%r): %r' % (long_description, e))
 
 tests_require = [
-    'pep257>=0.7.0',
-    'py>=1.4.31',
-    'pytest>=2.8.5',
-    'pytest-cov>=2.2.0',
-    'hypothesis==1.18.1',
-    'hypothesis-pytest>=0.19.0',
+    'coverage==4.1.b2',
+    'hypothesis==2.0.0',
+    'hypothesis-pytest==0.19.0',
+    'pep257==0.7.0',
+    'py==1.4.31',
+    'pytest==2.8.7',
+    'pytest-cov==2.2.0'
 ]
-
-class PyTest(Command):
-    user_options = []
-    def initialize_options(self): pass
-    def finalize_options(self): pass
-    def run(self):
-        from subprocess import call
-        errno = call(['py.test'])
-        raise SystemExit(errno)
 
 setup(
     name='bidict',
@@ -64,10 +56,9 @@ setup(
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],
-    cmdclass=dict(test=PyTest),
     tests_require=tests_require,
     extras_require=dict(
-        dev=['pre-commit'] + tests_require,
         test=tests_require,
+        dev=tests_require + ['pre-commit==0.7.6', 'tox==2.3.1'],
     ),
 )

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# this is what .travis.yml and tox.ini use to run tests
+
+set -ev
+
+COV="--cov=bidict"
+# With hypothesis>=1.19.0,
+# data generation is so slow when using --cov
+# that it can cause health checks to fail
+# in slow environments such as Travis-CI
+# with certain Python versions such as pypy.
+# Don't pass --cov in these cases:
+[[ $TRAVIS_PYTHON_VERSION =~ ^(3\.3|3\.4|pypy)$ ]] && COV=""
+py.test $COV || FAILED=1
+pep257 bidict || FAILED=1
+exit $FAILED

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy, pypy3
+envlist = py27, py33, py34, py35, pypy
 
 [testenv]
 commands =
     pip install -e .[test]
-    python setup.py test
+    ./test.sh


### PR DESCRIPTION
- use latest patch releases of all python versions via pyenv
- use caching to speed up travis builds
- peg to latest versions of test deps (including hypothesis 2.0)
- set hypothesis to strict
- explicitly set average_size on strategies that accept it
- drop pypy3, not worth supporting till it catches up to cpython
- only pass --cov for python27 and 35; with other versions, it slows down
  hypothesis data generation so much, the health checks fail
- refactor tox and travis setup to use new test.sh helper script