### PR TITLE
numerous improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,24 @@ Changelog
 .. include:: release-notifications.rst.inc
 
 
+0.14.2 (2017-12-06)
+-------------------
+
+- Make initializing (or updating an empty bidict) from only another
+  :class:`BidirectionalMapping <bidict.BidirectionalMapping>`
+  more efficient by skipping unnecessary duplication checking.
+
+- Fix accidental ignoring of specified ``base_type`` argument
+  when (un)pickling a :func:`namedbidict <bidict.namedbidict>`.
+
+- Fix incorrect inversion of
+  ``some_named_bidict.inv.[fwdname]_for`` and
+  ``some_named_bidict.inv.[invname]_for``.
+
+- Only warn when an unsupported Python version is detected
+  (e.g. Python < 2.7) rather than raising :class:`AssertionError`.
+
+
 0.14.1 (2017-11-28)
 -------------------
 
@@ -75,7 +93,7 @@ This release includes multiple API simplifications and improvements.
 
   The names of the
   :class:`bidict <bidict.bidict>`,
-  :class:`namedbidict <bidict.namedbidict>`, and
+  :func:`namedbidict <bidict.namedbidict>`, and
   :class:`frozenbidict <bidict.frozenbidict>` classes
   have been retained as all-lowercase
   so that they continue to match the case of

--- a/bidict/_bidict.py
+++ b/bidict/_bidict.py
@@ -108,21 +108,18 @@ class bidict(frozenbidict):  # noqa: N801; pylint: disable=invalid-name
 
     def popitem(self, *args, **kw):
         """Like :py:meth:`dict.popitem`."""
-        if not self.fwdm:
+        if not self:
             raise KeyError('popitem(): %s is empty' % self.__class__.__name__)
         key, val = self.fwdm.popitem(*args, **kw)
         del self.invm[val]
         return key, val
 
-    def setdefault(self, key, default=None):
-        """Like :py:meth:`dict.setdefault`."""
-        if key not in self:
-            self[key] = default
-        return self[key]
+    setdefault = MutableMapping.setdefault
 
     def update(self, *args, **kw):
         """Like :attr:`putall` with default duplication policies."""
-        self._update(False, self.on_dup_key, self.on_dup_val, self.on_dup_kv, *args, **kw)
+        if args or kw:
+            self._update(False, self.on_dup_key, self.on_dup_val, self.on_dup_kv, *args, **kw)
 
     def forceupdate(self, *args, **kw):
         """Like a bulk :attr:`forceput`."""
@@ -135,7 +132,8 @@ class bidict(frozenbidict):  # noqa: N801; pylint: disable=invalid-name
         If one of the given items causes an exception to be raised,
         none of the items is inserted.
         """
-        self._update(False, on_dup_key, on_dup_val, on_dup_kv, items)
+        if items:
+            self._update(False, on_dup_key, on_dup_val, on_dup_kv, items)
 
 
 # MutableMapping does not implement __subclasshook__.

--- a/bidict/_named.py
+++ b/bidict/_named.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Implements :class:`bidict.namedbidict`."""
+"""Implements :func:`bidict.namedbidict`."""
 
 import re
 
@@ -27,15 +27,15 @@ def namedbidict(typename, keyname, valname, base_type=bidict):
             raise ValueError('"%s" does not match pattern %s' %
                              (name, _LEGALNAMEPAT))
 
-    getfwd = lambda self: self
+    getfwd = lambda self: self.inv if self.isinv else self
     getfwd.__name__ = valname + '_for'
-    getfwd.__doc__ = '%s forward %s: %s → %s' % (typename, base_type.__name__, keyname, valname)
+    getfwd.__doc__ = u'%s forward %s: %s → %s' % (typename, base_type.__name__, keyname, valname)
 
-    getinv = lambda self: self.inv
+    getinv = lambda self: self if self.isinv else self.inv
     getinv.__name__ = keyname + '_for'
-    getinv.__doc__ = '%s inverse %s: %s → %s' % (typename, base_type.__name__, valname, keyname)
+    getinv.__doc__ = u'%s inverse %s: %s → %s' % (typename, base_type.__name__, valname, keyname)
 
-    __reduce__ = lambda self: (_make_empty, (typename, keyname, valname), self.__dict__)
+    __reduce__ = lambda self: (_make_empty, (typename, keyname, valname, base_type), self.__dict__)
     __reduce__.__name__ = '__reduce__'
     __reduce__.__doc__ = 'helper for pickle'
 
@@ -47,11 +47,11 @@ def namedbidict(typename, keyname, valname, base_type=bidict):
     return type(typename, (base_type,), __dict__)
 
 
-def _make_empty(typename, keyname, valname):
+def _make_empty(typename, keyname, valname, base_type):
     """
-    Create an empty instance of a custom bidict.
+    Create a named bidict with the indicated arguments and return an empty instance.
 
     Used to make :func:`bidict.namedbidict` instances picklable.
     """
-    named = namedbidict(typename, keyname, valname)
-    return named()
+    cls = namedbidict(typename, keyname, valname, base_type=base_type)
+    return cls()

--- a/bidict/compat.py
+++ b/bidict/compat.py
@@ -51,6 +51,7 @@ Compatibility helpers.
 from operator import methodcaller
 from platform import python_implementation
 from sys import version_info
+from warnings import warn
 
 _compose = lambda f, g: lambda x: f(g(x))
 
@@ -58,7 +59,8 @@ PY2 = version_info[0] == 2
 PYPY = python_implementation() == 'PyPy'
 
 if PY2:
-    assert version_info[1] > 6, 'Python >= 2.7 required'
+    if version_info[1] < 7:  # pragma: no cover
+        warn('Python < 2.7 is unsupported.')
     viewkeys = methodcaller('viewkeys')
     viewvalues = methodcaller('viewvalues')
     viewitems = methodcaller('viewitems')
@@ -67,6 +69,8 @@ if PY2:
     iteritems = methodcaller('iteritems')
     from itertools import izip
 else:
+    if version_info[1] < 3:  # pragma: no cover
+        warn('Python3 < 3.3 is unsupported.')
     viewkeys = methodcaller('keys')
     viewvalues = methodcaller('values')
     viewitems = methodcaller('items')

--- a/docs/namedbidict.rst.inc
+++ b/docs/namedbidict.rst.inc
@@ -8,13 +8,13 @@ a new bidirectional mapping type
 with custom attribute-based access to forward and inverse mappings::
 
     >>> from bidict import namedbidict
-    >>> ElementMap = namedbidict('ElementMap', 'symbol', 'element')
+    >>> ElementMap = namedbidict('ElementMap', 'symbol', 'name')
     >>> noble_gases = ElementMap(He='helium')
-    >>> noble_gases.element_for['He']
+    >>> noble_gases.name_for['He']
     'helium'
     >>> noble_gases.symbol_for['helium']
     'He'
-    >>> noble_gases.element_for['Ne'] = 'neon'
+    >>> noble_gases.name_for['Ne'] = 'neon'
     >>> del noble_gases.symbol_for['helium']
     >>> noble_gases
     ElementMap({'Ne': 'neon'})

--- a/tests/test_bidict.txt
+++ b/tests/test_bidict.txt
@@ -97,8 +97,8 @@ The rest of the ``MutableMapping`` interface is supported::
     >>> bi.get('one')
     1
     >>> bi.get('zero')
-    >>> bi.get('zero', 0)
-    0
+    >>> bi.get('zero', 'default')
+    'default'
     >>> list(bi.keys())
     ['one']
     >>> list(bi.values())
@@ -111,6 +111,10 @@ The rest of the ``MutableMapping`` interface is supported::
     2
     >>> bi.pop('one')
     1
+    >>> bi
+    bidict({'two': 2})
+    >>> bi.inv
+    bidict({2: 'two'})
     >>> bi.pop('wrong', 'number', 'of', 'args')
     Traceback (most recent call last):
         ...

--- a/tests/test_namedbidict.txt
+++ b/tests/test_namedbidict.txt
@@ -7,16 +7,25 @@
 Test script for :func:`bidict.namedbidict`::
 
     >>> from bidict import namedbidict
-    >>> ElementMap = namedbidict('ElementMap', 'symbol', 'element')
+    >>> ElementMap = namedbidict('ElementMap', 'symbol', 'name')
     >>> noble_gases = ElementMap(He='helium')
-    >>> noble_gases.element_for['He']
+    >>> noble_gases.name_for['He']
     'helium'
     >>> noble_gases.symbol_for['helium']
     'He'
-    >>> noble_gases.element_for['Ne'] = 'neon'
+    >>> noble_gases.name_for['Ne'] = 'neon'
     >>> del noble_gases.symbol_for['helium']
     >>> noble_gases
     ElementMap({'Ne': 'neon'})
+
+``.inv`` still works too::
+
+    >>> noble_gases.inv
+    ElementMap({'neon': 'Ne'})
+    >>> noble_gases.inv.name_for['Ne']
+    'neon'
+    >>> noble_gases.inv.symbol_for['neon']
+    'Ne'
 
 Pickling works::
 


### PR DESCRIPTION
- Make initializing (or updating an empty bidict) from only another BidirectionalMapping more efficient (skip dup checking).

- Fix accidental ignoring of specified base_type when (un)pickling namedbidicts.

- Fix incorrect inversion of some_named_bidict.inv.[fwdname]_for and some_named_bidict.inv.[invname]_for

- Only warn when unsupported Python version is detected.

- More tests.

TODO: update changelog