### PR TITLE
Fix #24 + other improvements.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,48 @@ Changelog
 .. include:: release-notifications.rst.inc
 
 
+0.15.0 (not yet released)
+-------------------------
+
+- Use weakrefs to refer to a bidict's inverse internally,
+  no longer creating a reference cycle.
+  Memory for a bidict that you create can now be reclaimed
+  as soon as you no longer hold any references to it.
+  Fixes `#24 <https://github.com/jab/bidict/issues/20>`_.
+
+Breaking API Changes
+++++++++++++++++++++
+
+- Rename ``fwd_cls`` → :attr:`fwdm_cls <bidict.frozenbidict.fwdm_cls>`
+
+- Rename ``inv_cls`` → :attr:`invm_cls <bidict.frozenbidict.invm_cls>`
+
+  :attr:`inv_cls <bidict.frozenbidict.inv_cls>`
+  now refers to a new classmethod that returns
+  the computed inverse bidict class,
+  not the user-overridable class of the backing inverse mapping.
+
+  This enabled improving the logic if you specify a different
+  :attr:`fwdm_cls <bidict.frozenbidict.fwdm_cls>` and
+  :attr:`invm_cls <bidict.frozenbidict.invm_cls>`
+  in a custom bidict subclass,
+  as in the :ref:`sorted-bidict-recipes`:
+  bidict now dynamically computes the
+  :attr:`inv_cls <bidict.frozenbidict.inv_cls>`
+  of your custom bidict to have the inverse
+  :attr:`fwdm_cls <bidict.frozenbidict.fwdm_cls>` and
+  :attr:`invm_cls <bidict.frozenbidict.invm_cls>`
+  of your custom bidict.
+
+  If creating a new instance of such a custom bidict
+  from the inverse of an existing instance,
+  the :attr:`fwdm_cls <bidict.frozenbidict.fwdm_cls>`
+  and :attr:`invm_cls <bidict.frozenbidict.invm_cls>`
+  of the new instance are no longer incorrectly swapped.
+
+- Rename ``isinv`` to ``_isinv``.
+
+
 0.14.2 (2017-12-06)
 -------------------
 

--- a/bidict/_abc.py
+++ b/bidict/_abc.py
@@ -18,7 +18,7 @@ class BidirectionalMapping(Mapping):  # pylint: disable=abstract-method
 
     .. py:attribute:: inv
 
-        The inverse mapping.
+        The inverse bidirectional mapping.
 
     .. py:attribute:: _subclsattrs
 

--- a/bidict/_named.py
+++ b/bidict/_named.py
@@ -27,15 +27,16 @@ def namedbidict(typename, keyname, valname, base_type=bidict):
             raise ValueError('"%s" does not match pattern %s' %
                              (name, _LEGALNAMEPAT))
 
-    getfwd = lambda self: self.inv if self.isinv else self
+    getfwd = lambda self: self.inv if self._isinv else self  # pylint: disable=protected-access
     getfwd.__name__ = valname + '_for'
     getfwd.__doc__ = u'%s forward %s: %s → %s' % (typename, base_type.__name__, keyname, valname)
 
-    getinv = lambda self: self if self.isinv else self.inv
+    getinv = lambda self: self if self._isinv else self.inv  # pylint: disable=protected-access
     getinv.__name__ = keyname + '_for'
     getinv.__doc__ = u'%s inverse %s: %s → %s' % (typename, base_type.__name__, valname, keyname)
 
-    __reduce__ = lambda self: (_make_empty, (typename, keyname, valname, base_type), self.__dict__)
+    __reduce__ = lambda self: (
+        _make_empty, (typename, keyname, valname, base_type), self.__dict_pickle_safe__)
     __reduce__.__name__ = '__reduce__'
     __reduce__.__doc__ = 'helper for pickle'
 

--- a/bidict/_ordered.py
+++ b/bidict/_ordered.py
@@ -54,7 +54,6 @@ class FrozenOrderedBidict(frozenbidict):
         """Like :meth:`collections.OrderedDict.copy`."""
         # This should be faster than ``return self.__class__(self)``.
         copy = object.__new__(self.__class__)
-        copy.isinv = self.isinv
         sntl = _make_sentinel()
         fwdm = {}
         invm = {}

--- a/docs/sortedbidicts.rst.inc
+++ b/docs/sortedbidicts.rst.inc
@@ -1,4 +1,4 @@
-.. _sortedbidicts:
+.. _sorted-bidict-recipes:
 
 Sorted Bidict Recipes
 #####################
@@ -10,9 +10,9 @@ but the excellent
 `sortedcollections <http://www.grantjenks.com/docs/sortedcollections/>`_
 libraries do.
 Armed with these along with bidict's
-:attr:`fwd_cls <bidict.BidictBase.fwd_cls>`
+:attr:`fwdm_cls <bidict.BidictBase.fwdm_cls>`
 and
-:attr:`inv_cls <bidict.BidictBase.inv_cls>`
+:attr:`invm_cls <bidict.BidictBase.invm_cls>`
 attributes,
 creating a sorted bidict type is dead simple::
 
@@ -22,14 +22,14 @@ creating a sorted bidict type is dead simple::
     >>> # and whose inverse items stay sorted by *their* keys (i.e. it and
     >>> # its inverse iterate over their items in different orders):
 
-    >>> class SortedBidict1(bidict.bidict):
-    ...     fwd_cls = sortedcontainers.SortedDict
-    ...     inv_cls = sortedcontainers.SortedDict
+    >>> class KeySortedBidict(bidict.bidict):
+    ...     fwdm_cls = sortedcontainers.SortedDict
+    ...     invm_cls = sortedcontainers.SortedDict
     ...     __reversed__ = lambda self: reversed(self.fwdm)
 
-    >>> b = SortedBidict1({'Tokyo': 'Japan', 'Cairo': 'Egypt'})
+    >>> b = KeySortedBidict({'Tokyo': 'Japan', 'Cairo': 'Egypt'})
     >>> b
-    SortedBidict1([('Cairo', 'Egypt'), ('Tokyo', 'Japan')])
+    KeySortedBidict([('Cairo', 'Egypt'), ('Tokyo', 'Japan')])
 
     >>> b['Lima'] = 'Peru'
 
@@ -48,17 +48,17 @@ creating a sorted bidict type is dead simple::
 
     >>> import sortedcollections
 
-    >>> class SortedBidict2(bidict.bidict):
-    ...     fwd_cls = sortedcontainers.SortedDict
-    ...     inv_cls = sortedcollections.ValueSortedDict
+    >>> class FwdKeySortedBidict(bidict.bidict):
+    ...     fwdm_cls = sortedcontainers.SortedDict
+    ...     invm_cls = sortedcollections.ValueSortedDict
     ...     __reversed__ = lambda self: reversed(self.fwdm)
 
-    >>> element_by_atomic_number = SortedBidict2({
+    >>> element_by_atomic_number = FwdKeySortedBidict({
     ...     3: 'lithium', 1: 'hydrogen', 2: 'helium'})
 
     >>> # stays sorted by key:
     >>> element_by_atomic_number
-    SortedBidict2([(1, 'hydrogen'), (2, 'helium'), (3, 'lithium')])
+    FwdKeySortedBidict([(1, 'hydrogen'), (2, 'helium'), (3, 'lithium')])
 
     >>> # .inv stays sorted by value:
     >>> list(element_by_atomic_number.inv.items())
@@ -69,15 +69,7 @@ creating a sorted bidict type is dead simple::
     >>> list(element_by_atomic_number.inv.items())
     [('hydrogen', 1), ('helium', 2), ('lithium', 3), ('beryllium', 4)]
 
-    >>> # order is preserved correctly when passing .inv back into constructor:
-    >>> atomic_number_by_element = SortedBidict2(element_by_atomic_number.inv)
-    >>> list(atomic_number_by_element.items()) == list(element_by_atomic_number.inv.items())
-    True
-    >>> # copies of .inv preserve order correctly too:
-    >>> list(element_by_atomic_number.inv.copy().items()) == list(atomic_number_by_element.items())
-    True
-
-    >>> # To pass method calls through to the _fwd SortedDict when not present
+    >>> # To pass method calls through to the fwdm SortedDict when not present
     >>> # on the bidict instance, provide a custom __getattribute__ method:
     >>> def __getattribute__(self, name):
     ...     try:
@@ -88,8 +80,8 @@ creating a sorted bidict type is dead simple::
     ...         except AttributeError:
     ...             raise e
 
-    >>> SortedBidict2.__getattribute__ = __getattribute__
+    >>> FwdKeySortedBidict.__getattribute__ = __getattribute__
 
-    >>> # bidict has no .peekitem attr, so the call is passed through to _fwd:
+    >>> # bidict has no .peekitem attr, so the call is passed through to fwdm:
     >>> element_by_atomic_number.peekitem()
     (4, 'beryllium')


### PR DESCRIPTION
- Use weakrefs to refer to a bidict's inverse to no longer create a reference
  cycle. Fixes #24.
- Rename fwd_cls to fwdm_cls.
- Rename inv_cls to invm_cls.
- inv_cls now returns the inverse class of the bidict, not its invm mapping.
- Rename isinv to _isinv.