### PR TITLE
make __repr__ less clever, small __iter__ optimization, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,7 @@ matrix:
 
 
     ## macOS
-    ### Only test one Python version since Travis's macOS builds are so slow.
-    #### Commented out since Travis does not maintain Python on macOS actively enough.
+    ### Commented out pending https://github.com/travis-ci/travis-ci/issues/2312
     ####- python: "2.7"
     ####  env: TASK=test
     ####  if: branch = master

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,15 @@ Changelog
   it now ensures it is :func:`callable`
   before returning the result of calling it.
 
+- Make :func:`bidict.FrozenOrderedBidict.__iter__` slightly more efficient.
+
+- :func:`~bidict.frozenbidict.__repr__` no longer dynamically checks
+  for a ``__reversed__`` method to determine whether to use an ordered or
+  unordered ``__repr__`` delegate. Now it always just calls the new
+  :func:`~bidict.frozenbidict.__repr_delegate__` instead, which may be
+  explicitly overridden as needed.
+
+
 Breaking API Changes
 ++++++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -196,10 +196,10 @@ that can't render and link this documentation properly
 and are seeing broken links,
 try these alternate links instead:
 
+.. [#fn-intro] `<docs/intro.rst>`_ | `<https://bidict.readthedocs.io/intro.html>`_
+
 .. [#fn-contributing] `<CONTRIBUTING.rst>`_ | `<https://bidict.readthedocs.io/contributors-guide.html>`_
 
 .. [#fn-changelog] `<CHANGELOG.rst>`_ | `<https://bidict.readthedocs.io/changelog.html>`_
-
-.. [#fn-intro] `<docs/intro.rst>`_ | `<https://bidict.readthedocs.io/intro.html>`_
 
 .. [#fn-learning] `<docs/learning-from-bidict.rst>`_ | `<https://bidict.readthedocs.io/learning-from-bidict.html>`_

--- a/bidict/_abc.py
+++ b/bidict/_abc.py
@@ -12,7 +12,7 @@ from collections import Mapping
 from .compat import iteritems
 
 
-class BidirectionalMapping(Mapping):  # pylint: disable=abstract-method
+class BidirectionalMapping(Mapping):  # pylint: disable=abstract-method,no-init
     """Abstract base class for bidirectional mappings.
 
     Extends :class:`collections.abc.Mapping` primarily by adding the :attr:`inv`

--- a/bidict/_frozen.py
+++ b/bidict/_frozen.py
@@ -15,7 +15,7 @@ from ._dup import RAISE, OVERWRITE, IGNORE
 from ._exc import (
     DuplicationError, KeyDuplicationError, ValueDuplicationError, KeyAndValueDuplicationError)
 from ._miss import _MISS
-from .compat import PY2, _compose, iteritems
+from .compat import PY2, iteritems
 from .util import pairs
 
 
@@ -168,12 +168,9 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
         if not self:
             return tmpl + ')'
         tmpl += '%r)'
-        # If we have a __reversed__ method, use an ordered repr. Python doesn't provide an
-        # Ordered or OrderedMapping ABC, otherwise we'd check that. (Must use getattr rather
-        # than hasattr since __reversed__ may be set to None.)
-        ordered = bool(getattr(self, '__reversed__', False))
-        delegate = _compose(list, iteritems) if ordered else dict
-        return tmpl % delegate(self)
+        return tmpl % self.__class__.__repr_delegate__(self)
+
+    __repr_delegate__ = dict
 
     def __hash__(self):
         """Return the hash of this bidict from its contained items."""

--- a/bidict/_ordered.py
+++ b/bidict/_ordered.py
@@ -13,7 +13,7 @@ from ._bidict import bidict
 from ._frozen import frozenbidict
 from ._marker import _Marker
 from ._miss import _MISS
-from .compat import iteritems, izip
+from .compat import _compose, iteritems, izip
 
 
 _PRV = 1
@@ -186,14 +186,15 @@ class FrozenOrderedBidict(frozenbidict):
         """Like :meth:`collections.OrderedDict.__iter__`."""
         fwdm = self.fwdm
         sntl = self.sntl
-        cur = sntl[_PRV if reverse else _NXT]
+        nextidx = _PRV if reverse else _NXT
+        cur = sntl[nextidx]
         while cur is not sntl:  # lgtm [py/comparison-using-is]
-            data, prv, nxt = cur
+            data = cur[0]
             korv = data[0]
             node = fwdm.get(korv)
             key = korv if node is cur else data[1]
             yield key
-            cur = prv if reverse else nxt
+            cur = cur[nextidx]
 
     def __reversed__(self):
         """Like :meth:`collections.OrderedDict.__reversed__`."""
@@ -220,6 +221,8 @@ class FrozenOrderedBidict(frozenbidict):
     def equals_order_sensitive(self, other):
         """Check equality with other with order sensitivity."""
         return self.__eq__(other, order_sensitive=True)
+
+    __repr_delegate__ = _compose(list, iteritems)
 
     # frozenbidict.__hash__ is also correct for ordered bidicts:
     # The value is derived from all contained items and insensitive to their order.

--- a/docs/sortedbidicts.rst.inc
+++ b/docs/sortedbidicts.rst.inc
@@ -25,7 +25,9 @@ creating a sorted bidict type is dead simple::
     >>> class KeySortedBidict(bidict.bidict):
     ...     fwdm_cls = sortedcontainers.SortedDict
     ...     invm_cls = sortedcontainers.SortedDict
-    ...     __reversed__ = lambda self: reversed(self.fwdm)
+    ...
+    ...     # Purely cosmetic, only necessary for nicer repr's
+    ...     __repr_delegate__ = lambda x: list(x.items())
 
     >>> b = KeySortedBidict({'Tokyo': 'Japan', 'Cairo': 'Egypt'})
     >>> b
@@ -51,7 +53,9 @@ creating a sorted bidict type is dead simple::
     >>> class FwdKeySortedBidict(bidict.bidict):
     ...     fwdm_cls = sortedcontainers.SortedDict
     ...     invm_cls = sortedcollections.ValueSortedDict
-    ...     __reversed__ = lambda self: reversed(self.fwdm)
+    ...
+    ...     # Purely cosmetic, only necessary for nicer repr's
+    ...     __repr_delegate__ = lambda x: list(x.items())
 
     >>> element_by_atomic_number = FwdKeySortedBidict({
     ...     3: 'lithium', 1: 'hydrogen', 2: 'helium'})

--- a/tests/test_subclasshook.py
+++ b/tests/test_subclasshook.py
@@ -26,7 +26,7 @@ class MyBidirectionalMapping(dict):
         return MyBidirectionalMapping(self.__inverted__())
 
 
-class OldStyleClass:
+class OldStyleClass:  # pylint: disable=old-style-class,no-init
     """In Python 2 this is an old-style class (not derived from object)."""
 
 


### PR DESCRIPTION
- Make :func:`bidict.FrozenOrderedBidict.__iter__` slightly more efficient.

- :func:`~bidict.frozenbidict.__repr__` no longer dynamically checks
  for a ``__reversed__`` method to determine whether to use an ordered or
  unordered ``__repr__`` delegate. Now it always just calls the new
  :func:`~bidict.frozenbidict.__repr_delegate__` instead, which may be
  explicitly overridden as needed.