### PR TITLE
code and documentation improvements

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,3 +3,4 @@ disable=too-many-ancestors,too-many-locals,too-few-public-methods,inconsistent-r
 
 # Maximum number of arguments for function / method
 max-args=9
+max-attributes=8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Changelog
 0.15.0 (not yet released)
 -------------------------
 
+- Use :ref:`slots` to speed up bidict attribute access and reduce memory usage.
+
 - Use weakrefs to refer to a bidict's inverse internally,
   no longer creating a strong reference cycle.
   Memory for a bidict that you create can now be reclaimed
@@ -65,6 +67,20 @@ Breaking API Changes
   of the new instance are no longer incorrectly swapped.
 
 - Rename ``isinv`` to ``_isinv``.
+
+- :class:`~bidict.DuplicationPolicy` now just extends :class:`object`
+  (rather than ``bidict._Marker``).
+  And its
+  :attr:`~bidict.DuplicationPolicy.RAISE`,
+  :attr:`~bidict.DuplicationPolicy.OVERWRITE`, and
+  :attr:`~bidict.DuplicationPolicy.IGNORE`
+  attributes now extend ``bidict._Marker``
+  (rather than :class:`~bidict.DuplicationPolicy`).
+  (So it is no longer possible to create an infinite chain like
+  ``DuplicationPolicy.RAISE.RAISE.RAISE...``.)
+
+- Pickling bidicts on Python 2 now requires the latest version of the
+  pickle protocol (specified via -1), e.g. ``pickle.dumps(mybidict, -1)``
 
 
 0.14.2 (2017-12-06)
@@ -226,8 +242,8 @@ This release includes multiple API simplifications and improvements.
 
 - Rename:
 
-    - ``bidict.BidictBase._fwd_class`` → :attr:`bidict.frozenbidict.fwd_cls`
-    - ``bidict.BidictBase._inv_class`` → :attr:`bidict.frozenbidict.inv_cls`
+    - ``bidict.BidictBase._fwd_class`` → ``bidict.frozenbidict.fwd_cls``
+    - ``bidict.BidictBase._inv_class`` → ``bidict.frozenbidict.inv_cls``
     - ``bidict.BidictBase._on_dup_key`` → :attr:`bidict.frozenbidict.on_dup_key`
     - ``bidict.BidictBase._on_dup_val`` → :attr:`bidict.frozenbidict.on_dup_val`
     - ``bidict.BidictBase._on_dup_kv`` → :attr:`bidict.frozenbidict.on_dup_kv`

--- a/bidict/__init__.py
+++ b/bidict/__init__.py
@@ -5,34 +5,39 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
+#==============================================================================
+#                    * Welcome to the bidict source code *
+#==============================================================================
+
+# Doing a code review? You'll find a "Code review nav" comment like the one
+# below at the top and bottom of the most important source files. This provides
+# a suggested path through the source while you're still getting familiar.
+#
+# Note: If you aren't reading this on https://github.com/jab/bidict, you may be
+# viewing an outdated version of the code. Please head to GitHub to review the
+# latest version, which contains important improvements over older versions.
+#
+# Thank you for reading and for any feedback you provide.
+
+#==============================================================================
+#                           * Code review nav *               Next: _abc.py →
+#==============================================================================
+
+
 """
 Efficient, Pythonic bidirectional map implementation and related functionality.
 
-See https://bidict.readthedocs.io for comprehensive documentation.
+If you are reading this elsewhere,
+please see https://bidict.readthedocs.io for the most up-to-date documentation,
+and https://github.com/jab/bidict for the most up-to-date code.
 
 .. :copyright: (c) 2018 Joshua Bronson.
 .. :license: MPLv2. See LICENSE for details.
-
 """
 
-# Welcome to the bidict source code.
-#
-# Beginning a code review? Excellent!
-#
-# This __init__.py just collects functionality implemented in the other files
-# and exports it under the `bidict` module namespace.
-#
-# If you're looking for an interesting place to head next, check out _abc.py.
-# There the BidirectionalMapping abstract base class (ABC) is defined, which
-# all the bidirectional mapping types that bidict provides are subclasses of.
-#
-# ONE MORE THING! If you are not reading this on https://github.com/jab/bidict
-# right now, you may not be viewing the latest version of the code. Please head
-# to https://github.com/jab/bidict to review the latest version, which contains
-# important improvements over older versions.
-#
-# Thank you for reading =)
-# —jab ʕ•●̫•ʔ
+# This __init__.py only collects functionality implemented in the rest of the
+# source and exports it under the `bidict` module namespace (via `__all__`).
 
 from ._abc import BidirectionalMapping
 from ._bidict import bidict
@@ -77,3 +82,8 @@ __all__ = (
     'pairs',
     'inverted',
 )
+
+
+#==============================================================================
+#                           * Code review nav *               Next: _abc.py →
+#==============================================================================

--- a/bidict/_abc.py
+++ b/bidict/_abc.py
@@ -5,7 +5,27 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Provides the :class:`BidirectionalMapping` abstract base class (ABC)."""
+
+#==============================================================================
+#                    * Welcome to the bidict source code *
+#==============================================================================
+
+# Doing a code review? You'll find a "Code review nav" comment like the one
+# below at the top and bottom of the most important source files. This provides
+# a suggested path through the source while you're still getting familiar.
+#
+# Note: If you aren't reading this on https://github.com/jab/bidict, you may be
+# viewing an outdated version of the code. Please head to GitHub to review the
+# latest version, which contains important improvements over older versions.
+#
+# Thank you for reading and for any feedback you provide.
+
+#==============================================================================
+#  ← Prev: __init__.py          * Code review nav *        Next: _frozen.py →
+#==============================================================================
+
+
+"""Provides the :class:`BidirectionalMapping` abstract base class."""
 
 from collections import Mapping
 
@@ -13,56 +33,57 @@ from .compat import iteritems
 
 
 class BidirectionalMapping(Mapping):  # pylint: disable=abstract-method,no-init
-    """Abstract base class for bidirectional mappings.
+    """Abstract base class (ABC) for bidirectional mapping types.
 
     Extends :class:`collections.abc.Mapping` primarily by adding the :attr:`inv`
     attribute, which holds a reference to the inverse mapping.
 
-    All the bidirectional mapping types that bidict provides subclass this.
-
-    .. py:attribute:: inv
-
-        The inverse bidirectional mapping.
-
-    .. py:attribute:: _subclsattrs
-
-        The attributes that :attr:`__subclasshook__` checks for to determine
-        whether a class is a subclass of :class:`BidirectionalMapping`.
+    Implements :attr:`__subclasshook__` such that any
+    :class:`~collections.abc.Mapping` that also provides an
+    :attr:`~BidirectionalMapping.inv` implementation
+    will be considered a (virtual) subclass of this ABC.
     """
 
     __slots__ = ()
 
+    #: The inverse bidirectional mapping.
+    #: Defaults to :obj:`NotImplemented`,
+    #: meant to be overridden by concrete subclasses.
+    #: See also :attr:`bidict.frozenbidict.inv`
     inv = NotImplemented
 
     def __inverted__(self):
         """Get an iterator over the items in :attr:`inv`.
 
-        This is functionally equivalent to iterating over each item in the
-        forward mapping and inverting each one on the fly, but this is more
-        efficient. Since we already have the inverted items stored in
-        :attr:`inv`, we can just iterate over them directly.
+        This is functionally equivalent to iterating over the items in the
+        forward mapping and inverting each one on the fly, but this provides a
+        more efficient implementation: Assuming the already-inverted items
+        are stored in :attr:`inv`, just return an iterator over them directly.
 
         Providing this default implementation enables external functions,
         particularly :func:`~bidict.inverted`, to use this optimized
         implementation when available, instead of having to invert on the fly.
-
-        .. seealso:: :func:`bidict.inverted`
+        See also :func:`bidict.inverted`
         """
         return iteritems(self.inv)
 
+    #: The attributes that :attr:`__subclasshook__` checks for to determine
+    #: whether a class is a subclass of :class:`BidirectionalMapping`.
     _subclsattrs = frozenset({
-        'inv',  # __inverted__ is just an optimization, not a requirement of the interface
-        # see "Mapping" in the table at
+        # (__inverted__ not included, as it's an optimization, not a requirement of the interface)
+        'inv',
+        # The following are all the methods provided by the `collections.abc.Mapping` interface.
+        # See "Mapping" in the table at
         # https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes
         '__getitem__', '__iter__', '__len__',  # abstract methods
         '__contains__', 'keys', 'items', 'values', 'get', '__eq__', '__ne__',  # mixin methods
     })
 
     @classmethod
-    def __subclasshook__(cls, C):  # noqa: N803 ("argument name should be lowercase")
-        # Standard to use "C" for this arg in __subclasshook__, e.g.:
+    def __subclasshook__(cls, C):  # noqa: N803 "argument name should be lowercase" -
+        # "C" is the standard name for this arg in __subclasshook__ implementations, see e.g.
         # https://github.com/python/cpython/blob/d505a2/Lib/_collections_abc.py#L93
-        """Check if C provides all the attributes in :attr:`_subclsattrs`.
+        """Check if *C* provides all the attributes in :attr:`_subclsattrs`.
 
         Causes conforming classes to be virtual subclasses automatically.
         """
@@ -72,3 +93,8 @@ class BidirectionalMapping(Mapping):  # pylint: disable=abstract-method,no-init
         if mro is None:
             return NotImplemented
         return all(any(B.__dict__.get(i) for B in mro) for i in cls._subclsattrs)
+
+
+#==============================================================================
+#  ← Prev: __init__.py          * Code review nav *        Next: _frozen.py →
+#==============================================================================

--- a/bidict/_dup.py
+++ b/bidict/_dup.py
@@ -5,30 +5,31 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
 """Provides bidict duplication behaviors."""
+
 
 from ._marker import _Marker
 
 
-class DuplicationPolicy(_Marker):
-    """
-    Provide RAISE, OVERWRITE, and IGNORE duplication policies.
+class DuplicationPolicy(object):
+    """Provides bidict's duplication policies.
 
-    .. py:attribute:: RAISE
-
-        Raise an exception when a duplication is encountered.
-
-    .. py:attribute:: OVERWRITE
-
-        Overwrite an existing item when a duplication is encountered.
-
-    .. py:attribute:: IGNORE
-
-        Keep the existing item and ignore the new item when a duplication is
-        encountered.
+    See also :ref:`values-must-be-unique`
     """
 
+    __slots__ = ()
 
-DuplicationPolicy.RAISE = RAISE = DuplicationPolicy('RAISE')
-DuplicationPolicy.OVERWRITE = OVERWRITE = DuplicationPolicy('OVERWRITE')
-DuplicationPolicy.IGNORE = IGNORE = DuplicationPolicy('IGNORE')
+    #: Raise an exception when a duplication is encountered.
+    RAISE = _Marker('RAISE')
+
+    #: Overwrite an existing item when a duplication is encountered.
+    OVERWRITE = _Marker('OVERWRITE')
+
+    #: Keep the existing item and ignore the new item when a duplication is encountered.
+    IGNORE = _Marker('IGNORE')
+
+
+RAISE = DuplicationPolicy.RAISE
+OVERWRITE = DuplicationPolicy.OVERWRITE
+IGNORE = DuplicationPolicy.IGNORE

--- a/bidict/_exc.py
+++ b/bidict/_exc.py
@@ -5,6 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
 """Provides all bidict exceptions."""
 
 
@@ -13,7 +14,9 @@ class BidictException(Exception):
 
 
 class DuplicationError(BidictException):
-    """Base class for exceptions raised when uniqueness is violated."""
+    """Base class for exceptions raised when uniqueness is violated
+    as per the RAISE duplication policy.
+    """
 
 
 class KeyDuplicationError(DuplicationError):
@@ -25,8 +28,7 @@ class ValueDuplicationError(DuplicationError):
 
 
 class KeyAndValueDuplicationError(KeyDuplicationError, ValueDuplicationError):
-    """
-    Raised when a given item's key and value are not unique.
+    """Raised when a given item's key and value are not unique.
 
     That is, its key duplicates that of another item,
     and its value duplicates that of a different other item.

--- a/bidict/_frozen.py
+++ b/bidict/_frozen.py
@@ -5,9 +5,29 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Implements :class:`frozenbidict`."""
 
-from collections import ItemsView
+#==============================================================================
+#                    * Welcome to the bidict source code *
+#==============================================================================
+
+# Doing a code review? You'll find a "Code review nav" comment like the one
+# below at the top and bottom of the most important source files. This provides
+# a suggested path through the source while you're still getting familiar.
+#
+# Note: If you aren't reading this on https://github.com/jab/bidict, you may be
+# viewing an outdated version of the code. Please head to GitHub to review the
+# latest version, which contains important improvements over older versions.
+#
+# Thank you for reading and for any feedback you provide.
+
+#==============================================================================
+#  ← Prev: _abc.py           * Code review nav *           Next: _bidict.py →
+#==============================================================================
+
+
+"""Implements :class:`frozenbidict`, the base class for all other bidict types."""
+
+from collections import ItemsView, Mapping
 from weakref import ref
 
 from ._abc import BidirectionalMapping
@@ -19,25 +39,15 @@ from .compat import PY2, iteritems
 from .util import pairs
 
 
-def _proxied(methodname, attrname='fwdm', doc=None):
-    """Make a func that calls the indicated method on the indicated attribute."""
-    def proxy(self, *args):
-        """(__doc__ set dynamically below)"""
-        attr = getattr(self, attrname)
-        meth = getattr(attr, methodname)
-        return meth(*args)
-    proxy.__name__ = methodname
-    proxy.__doc__ = doc or "Like dict's ``%s``." % methodname
-    return proxy
-
-
 # Since BidirectionalMapping implements __subclasshook__, and frozenbidict
 # provides all the required attributes that the __subclasshook__ checks for,
 # frozenbidict would be a (virtual) subclass of BidirectionalMapping even if
-# it didn't subclass it explicitly. But subclassing it explicitly allows
-# frozenbidict to inherit the optimized __inverted__ implementation that
-# BidirectionalMapping also provides.
-# pylint: disable=invalid-name,too-many-instance-attributes
+# it didn't subclass it explicitly. But subclassing BidirectionalMapping
+# explicitly allows frozenbidict to inherit any useful methods that
+# BidirectionalMapping provides that aren't part of the required interface,
+# such as its optimized __inverted__ implementation.
+
+# pylint: disable=invalid-name
 class frozenbidict(BidirectionalMapping):  # noqa: N801
     u"""
     Immutable, hashable bidict type.
@@ -55,6 +65,8 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
         Defaults to :attr:`~DuplicationPolicy.OVERWRITE`
         to match :class:`dict`'s behavior.
 
+        See also :ref:`extending`
+
     .. py:attribute:: on_dup_val
 
         The default :class:`DuplicationPolicy` used in the event that an item
@@ -66,6 +78,8 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
         Defaults to :attr:`~DuplicationPolicy.RAISE`
         to prevent unintended overwrite of another item.
 
+        See also :ref:`extending`
+
     .. py:attribute:: on_dup_kv
 
         The default :class:`DuplicationPolicy` used in the event that an item
@@ -76,6 +90,8 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
         :meth:`~bidict.bidict.update`).
         Defaults to ``None``, which causes the *on_dup_kv* policy to match
         whatever *on_dup_val* policy is in effect.
+
+        See also :ref:`extending`
 
     .. py:attribute:: fwdm
 
@@ -94,13 +110,22 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
         Defaults to :class:`dict`.
         Override this if you need different behavior.
 
+        See also :ref:`extending`
+
     .. py:attribute:: invm_cls
 
         The :class:`~collections.abc.Mapping` type
         used for the backing :attr:`invm` mapping.
         Defaults to :class:`dict`.
         Override this if you need different behavior.
+
+        See also :ref:`extending`
     """
+
+    __slots__ = ['fwdm', 'invm', '_inv', '_invref', '_hash']
+
+    if not PY2:
+        __slots__.append('__weakref__')
 
     on_dup_key = OVERWRITE
     on_dup_val = RAISE
@@ -108,8 +133,13 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
     fwdm_cls = dict
     invm_cls = dict
 
-    def __init__(self, *args, **kw):
-        """Like dict's ``__init__``."""
+    def __init__(self, *args, **kw):  # pylint: disable=super-init-not-called
+        """Make a new bidirectional dictionary.
+        The signature is the same as that of regular dictionaries.
+        Items passed in are added in the order they are passed,
+        respecting this bidict type's duplication policies along the way.
+        See also :attr:`on_dup_key`, :attr:`on_dup_val`, :attr:`on_dup_kv`
+        """
         self.fwdm = self.fwdm_cls()
         self.invm = self.invm_cls()
         self._init_inv()  # lgtm [py/init-calls-subclass]
@@ -118,7 +148,7 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
 
     @classmethod
     def inv_cls(cls):
-        """Return the inverse of this bidict class (with *fwdm_cls* and *invm_cls* swapped)."""
+        """The inverse of this bidict type, i.e. one with *fwdm_cls* and *invm_cls* swapped."""
         if cls.fwdm_cls is cls.invm_cls:
             return cls
         if not getattr(cls, '_inv_cls', None):
@@ -126,15 +156,12 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
                 fwdm_cls = cls.invm_cls
                 invm_cls = cls.fwdm_cls
                 inv_cls = cls
-            _Inv.__name__ = cls.__name__
-            _Inv.__doc__ = cls.__doc__
+            _Inv.__name__ = cls.__name__ + 'Inv'
             cls._inv_cls = _Inv
         return cls._inv_cls
 
     def _init_inv(self):
         self._inv = inv = object.__new__(self.inv_cls())
-        inv.fwdm_cls = self.invm_cls
-        inv.invm_cls = self.fwdm_cls
         inv.fwdm = self.invm
         inv.invm = self.fwdm
         inv._invref = ref(self)  # pylint: disable=protected-access
@@ -156,47 +183,69 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
         self._init_inv()
         return self._inv
 
-    @property
-    def __dict_pickle_safe__(self):
-        return dict(self.__dict__, _invref=None)
+    def __getstate__(self):
+        state = {}
+        for cls in self.__class__.__mro__:
+            slots = getattr(cls, '__slots__', ())
+            for slot in slots:
+                if hasattr(self, slot):
+                    state[slot] = getattr(self, slot)
+        state['__weakref__'] = None
+        state['_invref'] = None
+        return state
 
-    def __reduce__(self):
-        return self.__class__, (), self.__dict_pickle_safe__
+    def __setstate__(self, state):
+        for slot, value in iteritems(state):
+            if slot == '__weakref__':
+                continue
+            setattr(self, slot, value)
 
     def __repr__(self):
-        tmpl = self.__class__.__name__ + '('
+        """See :func:`repr`."""
+        clsname = self.__class__.__name__
         if not self:
-            return tmpl + ')'
-        tmpl += '%r)'
-        return tmpl % self.__class__.__repr_delegate__(self)
+            return '%s()' % clsname
+        return '%s(%r)' % (clsname, self.__repr_delegate__())
 
-    __repr_delegate__ = dict
+    def __repr_delegate__(self):
+        """The object used by :attr:`__repr__` to represent the contained items."""
+        return self.fwdm
 
     def __hash__(self):
-        """Return the hash of this bidict from its contained items."""
+        """The hash of this bidict as determined by its items."""
         if getattr(self, '_hash', None) is None:  # pylint: disable=protected-access
             # pylint: disable=protected-access,attribute-defined-outside-init
             self._hash = ItemsView(self)._hash()
         return self._hash
 
+    # The inherited Mapping.__eq__ implementation would work, but it's implemented in terms of an
+    # inefficient ``dict(self.items()) == dict(other.items())`` comparison, so override it with a
+    # more efficient implementation.
     def __eq__(self, other):
-        """Like :py:meth:`dict.__eq__`."""
-        # This should be faster than using Mapping's __eq__ implementation.
-        return self.fwdm == other
+        """``x.__eq__(other) <==> x == other``
 
-    def __ne__(self, other):
-        """Like :py:meth:`dict.__eq__`."""
-        # This should be faster than using Mapping's __ne__ implementation.
-        return self.fwdm != other
+        Equivalent to ``dict(x.items()) == dict(other.items())``
+        but more efficient.
 
+        Note this implementation of ``__eq__`` is inherited by subclasses of
+        this class, in particular by the ordered bidict subclasses, so ``==``
+        comparison is always order-insensitive.
+        See also :meth:`bidict.FrozenOrderedBidict.equals_order_sensitive`
+        """
+        if not isinstance(other, Mapping) or len(self) != len(other):
+            return False
+        selfget = self.get
+        return all(selfget(k, _MISS) == v for (k, v) in iteritems(other))
+
+    # The following methods mutate frozenbidicts and so are not public. But they are implemented in
+    # this immutable class (rather than the mutable `bidict` subclass) because they are used here
+    # during initialization (starting with the `_update` method). (Why is this? Because `__init__`
+    # and `update` share a lot of the same behavior (inserting the provided items while respecting
+    # the active duplication policies), so it makes sense for them to share implementation too.)
     def _pop(self, key):
         val = self.fwdm.pop(key)
         del self.invm[val]
         return val
-
-    def _clear(self):
-        self.fwdm.clear()
-        self.invm.clear()
 
     def _put(self, key, val, on_dup_key, on_dup_val, on_dup_kv):
         dedup_result = self._dedup_item(key, val, on_dup_key, on_dup_val, on_dup_kv)
@@ -329,8 +378,12 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
                 del fwdm[key]
 
     def copy(self):
-        """Like :py:meth:`dict.copy`."""
-        # This should be faster than ``return self.__class__(self)``.
+        """A shallow copy."""
+        # Could just ``return self.__class__(self)`` here instead, but the below is faster. It uses
+        # object.__new__ to create a copy instance while bypassing its __init__, which would result
+        # in copying this bidict's items into the copy instance one at a time. Instead, make whole
+        # copies of each of the backing mappings, and make them the backing mappings of the copy,
+        # avoiding copying items one at a time.
         copy = object.__new__(self.__class__)
         copy.fwdm = self.fwdm.copy()
         copy.invm = self.invm.copy()
@@ -338,22 +391,50 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
         return copy
 
     __copy__ = copy
-    __len__ = _proxied('__len__')
-    __iter__ = _proxied('__iter__')
-    __getitem__ = _proxied('__getitem__')
-    values = _proxied('keys', attrname='inv')
-    values.__doc__ = \
-        "B.values() -> a set-like object providing a view on B's values.\n\n" \
-        'Note that because values of a :class:`~bidict.BidirectionalMapping` are\n' \
-        'also keys of its inverse, this returns a :class:`~collections.abc.KeysView`\n' \
-        'rather than a :class:`~collections.abc.ValuesView`, conferring set-alike benefits.'
-    if PY2:
-        viewkeys = _proxied('viewkeys')
 
-        viewvalues = _proxied('viewkeys', attrname='inv',
-                              doc=values.__doc__.replace('values()', 'viewvalues()'))
-        values.__doc__ = "Like dict's ``values``."
+    def __len__(self):
+        """The number of contained items."""
+        return len(self.fwdm)
+
+    def __iter__(self):
+        """Iterator over the contained items."""
+        return iter(self.fwdm)
+
+    def __getitem__(self, key):
+        """``x.__getitem__(key) <==> x[key]``"""
+        return self.fwdm[key]
+
+    def values(self):
+        """A set-like object providing a view on the contained values.
+
+        Note that because the values of a :class:`~bidict.BidirectionalMapping`
+        are the keys of its inverse,
+        this returns a :class:`~collections.abc.KeysView`
+        rather than a :class:`~collections.abc.ValuesView`,
+        which has the advantage of supporting set operations.
+        """
+        return self.inv.keys()
+
+    if PY2:
+        def viewkeys(self):
+            """A set-like object providing a view on the contained keys."""
+            return self.fwdm.viewkeys()
+
+        def viewvalues(self):  # noqa: D102; pylint: disable=missing-docstring
+            return self.inv.viewkeys()
+        viewvalues.__doc__ = values.__doc__
+        values.__doc__ = "A list of the contained values."
 
         def viewitems(self):
-            """Like dict's ``viewitems``."""
+            """A set-like object providing a view on the contained items."""
             return ItemsView(self)
+
+        # __ne__ added automatically in Python 3 when you implement __eq__, but not in Python 2.
+        def __ne__(self, other):
+            """``x.__ne__(other) <==> x != other``"""
+            return not self == other  # Implement __ne__ in terms of __eq__.
+
+
+#==============================================================================
+#  ← Prev: _abc.py           * Code review nav *           Next: _bidict.py →
+#==============================================================================

--- a/bidict/_marker.py
+++ b/bidict/_marker.py
@@ -5,10 +5,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Provides :class:`_Marker` for representing singletons."""
+
+"""Provides :class:`_Marker`, an internal type for representing singletons."""
 
 
 class _Marker(object):
+
+    __slots__ = ('name',)
+
     def __init__(self, name):
         self.name = name
 

--- a/bidict/_miss.py
+++ b/bidict/_miss.py
@@ -5,7 +5,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Provides the "MISSING" marker."""
+
+"""Provides the :obj:`_MISS` sentinel, for internally signaling "missing/not found"."""
 
 from ._marker import _Marker
 

--- a/bidict/_named.py
+++ b/bidict/_named.py
@@ -36,7 +36,7 @@ def namedbidict(typename, keyname, valname, base_type=bidict):
     getinv.__doc__ = u'%s inverse %s: %s → %s' % (typename, base_type.__name__, valname, keyname)
 
     __reduce__ = lambda self: (
-        _make_empty, (typename, keyname, valname, base_type), self.__dict_pickle_safe__)
+        _make_empty, (typename, keyname, valname, base_type), self.__getstate__())
     __reduce__.__name__ = '__reduce__'
     __reduce__.__doc__ = 'helper for pickle'
 

--- a/bidict/compat.py
+++ b/bidict/compat.py
@@ -5,6 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
 u"""
 Compatibility helpers.
 
@@ -18,62 +19,70 @@ Compatibility helpers.
 
     .. py:attribute:: viewkeys
 
-        viewkeys(D) → a set-like object providing a view on D's keys.
+        viewkeys(x) → a set-like object providing a view on x's keys.
 
     .. py:attribute:: viewvalues
 
-        viewvalues(D) → an object providing a view on D's values.
+        viewvalues(x) → an object providing a view on x's values.
 
     .. py:attribute:: viewitems
 
-        viewitems(D) → a set-like object providing a view on D's items.
+        viewitems(x) → a set-like object providing a view on x's items.
 
     .. py:attribute:: iterkeys
 
-        iterkeys(D) → an iterator over the keys of D.
+        iterkeys(x) → an iterator over the keys of x.
 
     .. py:attribute:: itervalues
 
-        itervalues(D) → an iterator over the values of D.
+        itervalues(x) → an iterator over the values of x.
 
     .. py:attribute:: iteritems
 
-        iteritems(D) → an iterator over the (key, value) items of D.
+        iteritems(x) → an iterator over the (key, value) items of x.
 
     .. py:attribute:: izip
 
         Alias for :func:`zip` on Python 3 / ``itertools.izip`` on Python 2.
-
 """
-
-# pylint: disable-all
 
 from operator import methodcaller
 from platform import python_implementation
 from sys import version_info
 from warnings import warn
 
-_compose = lambda f, g: lambda x: f(g(x))
-
 PY2 = version_info[0] == 2
 PYPY = python_implementation() == 'PyPy'
 
+# Without the following, pylint gives lots of false positives like
+# "Constant name "viewkeys" doesn't conform to UPPER_CASE naming style"
+# pylint: disable=invalid-name
+
 if PY2:
+
     if version_info[1] < 7:  # pragma: no cover
         warn('Python < 2.7 is unsupported.')
+
     viewkeys = methodcaller('viewkeys')
     viewvalues = methodcaller('viewvalues')
     viewitems = methodcaller('viewitems')
     iterkeys = methodcaller('iterkeys')
     itervalues = methodcaller('itervalues')
     iteritems = methodcaller('iteritems')
-    from itertools import izip
+    from itertools import izip  # pylint: disable=no-name-in-module,unused-import
+
 else:
+
     if version_info[1] < 3:  # pragma: no cover
         warn('Python3 < 3.3 is unsupported.')
+
     viewkeys = methodcaller('keys')
     viewvalues = methodcaller('values')
     viewitems = methodcaller('items')
+
+    def _compose(f, g):
+        return lambda x: f(g(x))
+
     iterkeys = _compose(iter, viewkeys)
     itervalues = _compose(iter, viewvalues)
     iteritems = _compose(iter, viewitems)

--- a/bidict/util.py
+++ b/bidict/util.py
@@ -5,7 +5,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Utilities for working with one-to-one relations."""
+
+"""Useful functions for working with bidirectional mappings and related data."""
 
 from collections import Mapping
 from itertools import chain
@@ -56,8 +57,7 @@ def inverted(obj):
 
     Otherwise, return an iterator that iterates over the items in `obj`,
     inverting each item on the fly.
-
-    .. seealso:: :attr:`bidict.BidirectionalMapping.__inverted__`
+    See also :attr:`bidict.BidirectionalMapping.__inverted__`
     """
     inv = getattr(obj, '__inverted__', None)
     return inv() if callable(inv) else _inverted_on_the_fly(obj)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,9 +10,12 @@ bidict
 
 .. automodule:: bidict
     :members:
+    :member-order: bysource
     :special-members:
-    :exclude-members: __dict__,__weakref__
-    :private-members:
+    :show-inheritance:
+    :undoc-members:
+    :exclude-members: __abstractmethods__,__dict__,__module__,__weakref__
+..  :inherited-members:
 
 
 bidict.compat

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -16,7 +16,7 @@ is the main bidirectional map data structure provided.
 It implements the familiar API you're used to from dict::
 
     >>> from bidict import bidict
-    >>> element_by_symbol = bidict(H='hydrogen')
+    >>> element_by_symbol = bidict({'H': 'hydrogen'})
     >>> element_by_symbol
     bidict({'H': 'hydrogen'})
     >>> element_by_symbol['H']
@@ -33,7 +33,7 @@ But it also maintains the inverse bidict via the
 Concise, efficient, Pythonic.
 
 
-Why Can't I Just Use A dict?
+Why can't I just use a dict?
 ----------------------------
 
 A skeptic writes:
@@ -92,9 +92,8 @@ Additional Functionality
 ------------------------
 
 Besides the standard :class:`bidict.bidict` class,
-the :mod:`bidict` package provides other bidict variants,
-as well as additional tools
-for working with one-to-one relations:
+the :mod:`bidict` package provides other bidirectional map variants,
+as well as some utilities for working with them and related objects:
 
 - :class:`bidict.BidirectionalMapping`
 - :func:`bidict.namedbidict`

--- a/docs/learning-from-bidict.rst
+++ b/docs/learning-from-bidict.rst
@@ -28,17 +28,29 @@ Python's data model
 
   - See :ref:`sorted-bidict-recipes` for example
 
-- Using :meth:`object.__reduce__` to make an object pickleable
+- Using
+  :meth:`object.__getstate__`,
+  :meth:`object.__setstate__`, and
+  :meth:`object.__reduce__` to make an object pickleable
   that otherwise wouldn't be,
   due to e.g. using weakrefs (see below)
+
+- Using :ref:`slots` to speed up attribute access and reduce memory usage
+
+  - Must be careful with pickling and weakrefs, see ``frozenbidict.__getstate__``
 
 - Making an immutable type hashable,
   i.e. insertable into :class:`dict`\s and :class:`set`\s
 
   - See :meth:`object.__hash__` and :meth:`object.__eq__` docs
 
-  - If overriding :meth:`object.__eq__`, don't forget to override
-    :meth:`object.__ne__`
+  - If overriding :meth:`object.__eq__`:
+
+    - Don't forget to override
+      :meth:`object.__ne__` (automatic for Python 3, not Python 2)
+
+    - See https://eev.ee/blog/2012/03/24/python-faq-equality/
+      ("When Python sees a == b, it tries the following...")
 
   - How this affects hashable ordered collections
     like :class:`~bidict.FrozenOrderedBidict`
@@ -106,6 +118,15 @@ Using :mod:`weakref`
 ====================
 
 - See :ref:`inv-avoids-reference-cycles`
+
+
+Other interesting things discovered in the standard library
+===========================================================
+
+- :mod:`reprlib` and :func:`reprlib.recursive_repr`
+  (but not needed for bidict because there's no way to insert a bidict into itself)
+- :func:`operator.methodcaller`
+- :attr:`platform.python_implementation`
 
 
 :func:`~collections.namedtuple`-style dynamic class generation

--- a/docs/orderedbidict.rst.inc
+++ b/docs/orderedbidict.rst.inc
@@ -101,8 +101,11 @@ For order-sensitive equality tests, use
     False
 
 Note that this differs from the behavior of
-:meth:`collections.OrderedDict.__eq__`,
-by recommendation of Raymond Hettinger himself.
+:class:`collections.OrderedDict`\'s ``__eq__``,
+by recommendation of Raymond Hettinger (the author) himself
+(who said that making OrderedDict's ``__eq__``
+`intransitive <https://github.com/cosmologicon/pywat/issues/38>`_
+was a mistake).
 
 :class:`~bidict.OrderedBidict` also comes in a frozen flavor.
 See the :class:`~bidict.FrozenOrderedBidict`

--- a/docs/other-bidict-types.rst
+++ b/docs/other-bidict-types.rst
@@ -45,4 +45,4 @@ and serves as a base class for mutable bidict types to extend.
 
 .. include:: extending.rst.inc
 
-Proceed to :ref:`other-functionality`.
+Next proceed to :ref:`other-functionality`.

--- a/docs/sortedbidicts.rst.inc
+++ b/docs/sortedbidicts.rst.inc
@@ -26,7 +26,7 @@ creating a sorted bidict type is dead simple::
     ...     fwdm_cls = sortedcontainers.SortedDict
     ...     invm_cls = sortedcontainers.SortedDict
     ...
-    ...     # Purely cosmetic, only necessary for nicer repr's
+    ...     # Include this for nicer repr's:
     ...     __repr_delegate__ = lambda x: list(x.items())
 
     >>> b = KeySortedBidict({'Tokyo': 'Japan', 'Cairo': 'Egypt'})
@@ -54,7 +54,7 @@ creating a sorted bidict type is dead simple::
     ...     fwdm_cls = sortedcontainers.SortedDict
     ...     invm_cls = sortedcollections.ValueSortedDict
     ...
-    ...     # Purely cosmetic, only necessary for nicer repr's
+    ...     # Include this for nicer repr's:
     ...     __repr_delegate__ = lambda x: list(x.items())
 
     >>> element_by_atomic_number = FwdKeySortedBidict({

--- a/docs/values-unique.rst.inc
+++ b/docs/values-unique.rst.inc
@@ -1,3 +1,5 @@
+.. _values-must-be-unique:
+
 Values Must Be Unique
 +++++++++++++++++++++
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ test=pytest
 
 ; https://flake8.readthedocs.io/en/latest/config.html
 [flake8]
-ignore = E126,E128,E731
+ignore = E126,E128,E265,E731
 max-line-length = 100
 
 ; https://pydocstyle.readthedocs.io/en/latest/snippets/config.html

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -20,7 +20,7 @@ from bidict import (
     IGNORE, OVERWRITE, RAISE,
     bidict, namedbidict, OrderedBidict,
     frozenbidict, FrozenOrderedBidict)
-from bidict.compat import PYPY, iteritems
+from bidict.compat import PY2, PYPY, iteritems
 
 
 settings.register_profile('default', settings(max_examples=200, deadline=None))
@@ -61,7 +61,8 @@ inititems = itemlists.map(dedup)
 @given(init=inititems)
 def test_pickle_roundtrips(B, init):  # noqa
     bi = B(init)
-    dumped = dumps(bi)
+    # Must use -1 for "latest pickle protocol" in Python 2
+    dumped = dumps(bi, -1) if PY2 else dumps(bi)
     roundtripped = loads(dumped)
     assert roundtripped == bi
 


### PR DESCRIPTION
- Use `__slots__` to speed up attribute access and decrease memory usage
  (adding _SlotPickleMixin to preserve pickleability)
- "Code review nav" comments
- Remove _clear from frozenbidict, leaving only the public `clear` methods on
  the mutable bidict types. Much clearer now! (ducks)
- Improve `pop` and `popitem` signatures. No need for them to take *args/**kw.
- Make bidict extend MutableMapping directly rather than registering it as a
  virtual subclass. Leave a comment explaining that it inherits
  MutableMapping's setdefault implementation now that it isn't added manually.
- Make the DuplicationPolicy class just a namespace holding
  RAISE, OVERWRITE, and IGNORE, not a _Marker itself.
  Make RAISE, OVERWRITE, and IGNORE just _Markers, not `DuplicationPolicy`s.
- Various other code and docs improvements.