### PR TITLE
improvements to namedbidict and tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,8 +79,19 @@ Breaking API Changes
   (So it is no longer possible to create an infinite chain like
   ``DuplicationPolicy.RAISE.RAISE.RAISE...``.)
 
-- Pickling bidicts on Python 2 now requires the latest version of the
-  pickle protocol (specified via -1), e.g. ``pickle.dumps(mybidict, -1)``
+- :func:`~bidict.namedbidict` now raises :class:`TypeError` if the provided
+  ``base_type`` is not a subclass of :class:`~bidict.frozenbidict`.
+
+- Pickling ordered bidicts now requires
+  at least version 2 of the pickle protocol.
+  If you are using Python 3,
+  :attr:`pickle.DEFAULT_PROTOCOL` is 3 anyway,
+  so this will not affect you.
+  However if you are using in Python 2,
+  :attr:`~pickle.DEFAULT_PROTOCOL` is 0,
+  so you must now explicitly specify the version
+  in your :func:`pickle.dumps` calls,
+  e.g. ``pickle.dumps(ob, 2)``.
 
 
 0.14.2 (2017-12-06)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python36-x64"
 
 build_script:

--- a/bidict/_frozen.py
+++ b/bidict/_frozen.py
@@ -289,19 +289,22 @@ class frozenbidict(BidirectionalMapping):  # noqa: N801
                 raise KeyAndValueDuplicationError(key, val)
             elif on_dup_kv is IGNORE:
                 return
-            # else on_dup_kv is OVERWRITE. Fall through to return on last line.
+            assert on_dup_kv is OVERWRITE, 'invalid on_dup_kv: %r' % on_dup_kv
+            # Fall through to the return statement on the last line.
         elif isdupkey:
             if on_dup_key is RAISE:
                 raise KeyDuplicationError(key)
             elif on_dup_key is IGNORE:
                 return
-            # else on_dup_key is OVERWRITE. Fall through to return on last line.
+            assert on_dup_key is OVERWRITE, 'invalid on_dup_key: %r' % on_dup_key
+            # Fall through to the return statement on the last line.
         elif isdupval:
             if on_dup_val is RAISE:
                 raise ValueDuplicationError(val)
             elif on_dup_val is IGNORE:
                 return
-            # else on_dup_val is OVERWRITE. Fall through to return on last line.
+            assert on_dup_val is OVERWRITE, 'invalid on_dup_val: %r' % on_dup_val
+            # Fall through to the return statement on the last line.
         # else neither isdupkey nor isdupval.
         return isdupkey, isdupval, invbyval, fwdbykey
 

--- a/bidict/_named.py
+++ b/bidict/_named.py
@@ -23,7 +23,7 @@ def namedbidict(typename, keyname, valname, base_type=bidict):
 
     Analagous to :func:`collections.namedtuple`.
     """
-    if not issubclass(base_type, frozenbidict):
+    if not isinstance(base_type, type) or not issubclass(base_type, frozenbidict):
         raise TypeError('base_type must be a subclass of frozenbidict')
 
     for name in typename, keyname, valname:
@@ -43,15 +43,14 @@ def namedbidict(typename, keyname, valname, base_type=bidict):
         def __reduce__(self):
             return (_make_empty, (typename, keyname, valname, base_type), self.__getstate__())
 
-
     bname = base_type.__name__
     fname = valname + '_for'
     iname = keyname + '_for'
     names = dict(typename=typename, bname=bname, keyname=keyname, valname=valname)
     fdoc = u'{typename} forward {bname}: {keyname} → {valname}'.format(**names)
     idoc = u'{typename} inverse {bname}: {valname} → {keyname}'.format(**names)
-    setattr(_Named, fname, property(_Named._getfwd, doc=fdoc))
-    setattr(_Named, iname, property(_Named._getinv, doc=idoc))
+    setattr(_Named, fname, property(_Named._getfwd, doc=fdoc))  # pylint: disable=protected-access
+    setattr(_Named, iname, property(_Named._getinv, doc=idoc))  # pylint: disable=protected-access
 
     _Named.__name__ = typename
     return _Named

--- a/bidict/_named.py
+++ b/bidict/_named.py
@@ -9,6 +9,7 @@
 
 import re
 
+from ._frozen import frozenbidict
 from ._bidict import bidict
 
 
@@ -22,36 +23,42 @@ def namedbidict(typename, keyname, valname, base_type=bidict):
 
     Analagous to :func:`collections.namedtuple`.
     """
+    if not issubclass(base_type, frozenbidict):
+        raise TypeError('base_type must be a subclass of frozenbidict')
+
     for name in typename, keyname, valname:
         if not _LEGALNAMERE.match(name):
-            raise ValueError('"%s" does not match pattern %s' %
-                             (name, _LEGALNAMEPAT))
+            raise ValueError('%r does not match pattern %s' % (name, _LEGALNAMEPAT))
 
-    getfwd = lambda self: self.inv if self._isinv else self  # pylint: disable=protected-access
-    getfwd.__name__ = valname + '_for'
-    getfwd.__doc__ = u'%s forward %s: %s → %s' % (typename, base_type.__name__, keyname, valname)
+    class _Named(base_type):
 
-    getinv = lambda self: self if self._isinv else self.inv  # pylint: disable=protected-access
-    getinv.__name__ = keyname + '_for'
-    getinv.__doc__ = u'%s inverse %s: %s → %s' % (typename, base_type.__name__, valname, keyname)
+        __slots__ = ()
 
-    __reduce__ = lambda self: (
-        _make_empty, (typename, keyname, valname, base_type), self.__getstate__())
-    __reduce__.__name__ = '__reduce__'
-    __reduce__.__doc__ = 'helper for pickle'
+        def _getfwd(self):
+            return self.inv if self._isinv else self  # pylint: disable=protected-access
 
-    __dict__ = {
-        getfwd.__name__: property(getfwd),
-        getinv.__name__: property(getinv),
-        '__reduce__': __reduce__,
-    }
-    return type(typename, (base_type,), __dict__)
+        def _getinv(self):
+            return self if self._isinv else self.inv  # pylint: disable=protected-access
+
+        def __reduce__(self):
+            return (_make_empty, (typename, keyname, valname, base_type), self.__getstate__())
+
+
+    bname = base_type.__name__
+    fname = valname + '_for'
+    iname = keyname + '_for'
+    names = dict(typename=typename, bname=bname, keyname=keyname, valname=valname)
+    fdoc = u'{typename} forward {bname}: {keyname} → {valname}'.format(**names)
+    idoc = u'{typename} inverse {bname}: {valname} → {keyname}'.format(**names)
+    setattr(_Named, fname, property(_Named._getfwd, doc=fdoc))
+    setattr(_Named, iname, property(_Named._getinv, doc=idoc))
+
+    _Named.__name__ = typename
+    return _Named
 
 
 def _make_empty(typename, keyname, valname, base_type):
-    """
-    Create a named bidict with the indicated arguments and return an empty instance.
-
+    """Create a named bidict with the indicated arguments and return an empty instance.
     Used to make :func:`bidict.namedbidict` instances picklable.
     """
     cls = namedbidict(typename, keyname, valname, base_type=base_type)

--- a/bidict/_ordered.py
+++ b/bidict/_ordered.py
@@ -169,7 +169,7 @@ class FrozenOrderedBidict(frozenbidict):
             assert oldnodeinv is nodefwd
             invm[val] = nodefwd
             node = nodefwd
-        elif isdupval:
+        else:  # isdupval
             datainv = nodeinv[0]
             oldkey = _get_other(datainv, val)
             oldval = _MISS
@@ -202,7 +202,7 @@ class FrozenOrderedBidict(frozenbidict):
             assert tmp is nodefwd
             invm[oldval] = nodefwd
             assert fwdm[key] is nodefwd
-        elif isdupval:
+        else:  # isdupval
             nodeinv[0] = (oldkey, val)
             tmp = fwdm.pop(key)
             assert tmp is nodeinv

--- a/docs/sortedbidicts.rst.inc
+++ b/docs/sortedbidicts.rst.inc
@@ -73,6 +73,16 @@ creating a sorted bidict type is dead simple::
     >>> list(element_by_atomic_number.inv.items())
     [('hydrogen', 1), ('helium', 2), ('lithium', 3), ('beryllium', 4)]
 
+    >>> # This works because a bidict whose fwdm_cls differs from its invm_cls calculates
+    >>> # its inverse class (which has fwdm_cls and invm_cls swapped) automatically:
+    >>> inv_cls = FwdKeySortedBidict.inv_cls()
+    >>> inv_cls.__name__
+    'FwdKeySortedBidictInv'
+    >>> FwdKeySortedBidict.fwdm_cls is inv_cls.invm_cls
+    True
+    >>> FwdKeySortedBidict.invm_cls is inv_cls.fwdm_cls
+    True
+
     >>> # To pass method calls through to the fwdm SortedDict when not present
     >>> # on the bidict instance, provide a custom __getattribute__ method:
     >>> def __getattribute__(self, name):

--- a/tests/test_bidict.txt
+++ b/tests/test_bidict.txt
@@ -153,6 +153,12 @@ Empty update is a no-op::
     >>> bi
     bidict()
 
+Not part of the public API, but test this anyway for the coverage::
+
+    >>> bi._update(False, bi.on_dup_key, bi.on_dup_val, bi.on_dup_kv)
+    >>> bi
+    bidict()
+
 Initializing with different keys mapping to the same value fails::
 
     >>> bidict([(1, 1), (2, 1)])

--- a/tests/test_eq_and_hash.py
+++ b/tests/test_eq_and_hash.py
@@ -82,7 +82,8 @@ def test_eq_and_hash(b, other):
         if are_equal and both_hashable:
             assert hash(b) == hash(other)
 
-        if hasattr(b, 'equals_order_sensitive') and hasattr(other, '__reversed__'):
+        if hasattr(b, 'equals_order_sensitive'):
             are_equal_ordered = b.equals_order_sensitive(other)
-            should_be_equal_ordered = OrderedDict(b) == OrderedDict(other)
+            should_be_equal_ordered = OrderedDict(b) == (
+                OrderedDict(other) if isinstance(other, Mapping) else other)
             assert are_equal_ordered == should_be_equal_ordered

--- a/tests/test_namedbidict.txt
+++ b/tests/test_namedbidict.txt
@@ -71,3 +71,11 @@ Test ``base_type`` keyword arg::
     Traceback (most recent call last):
         ...
     TypeError...
+
+    >>> exc = None
+    >>> try:
+    ...     namedbidict('ElMap', 'sym', 'el', base_type='not a bidict')
+    ... except TypeError as e:
+    ...     exc = e
+    >>> exc is not None
+    True

--- a/tests/test_orderedbidict.txt
+++ b/tests/test_orderedbidict.txt
@@ -10,20 +10,34 @@ due to reliance on side effects in assert statements)::
 
     >>> from bidict import OrderedBidict, DuplicationError, RAISE, OVERWRITE
     >>> b = OrderedBidict([(0, 1)])
+    >>> exc = None
     >>> try:
     ...     b.update([(0, 2), (3, 4), (5, 4)])
-    ... except DuplicationError:
-    ...     pass
+    ... except DuplicationError as e:
+    ...     exc = e
+    >>> exc is not None
+    True
     >>> len(b.inv)
     1
+    >>> exc = None
     >>> try:
     ...     b.putall([(2, 1), (2, 3)], on_dup_key=RAISE, on_dup_val=OVERWRITE)
-    ... except DuplicationError:
-    ...     pass
+    ... except DuplicationError as e:
+    ...     exc = e
+    >>> exc is not None
+    True
     >>> len(b)
     1
     >>> b.forceupdate([(0, 1), (2, 3), (0, 3)])
-    >>> len(b)
-    1
-    >>> 2 in b
-    False
+    >>> b
+    OrderedBidict([(0, 3)])
+
+Test iterating over an ordered bidict as well as reversing::
+
+    >>> b[4] = 5
+    >>> b
+    OrderedBidict([(0, 3), (4, 5)])
+    >>> list(iter(b))
+    [0, 4]
+    >>> list(reversed(b))
+    [4, 0]


### PR DESCRIPTION
- test python 2.7 on appveyor instead of 3.5
- namedbidict improvements
  - raise TypeError if base_type is not a frozenbidict subclass
  - rewrite the code to be clearer
- improve test coverage