### PR TITLE
numerous code improvements

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,11 @@
-[MESSAGES CONTROL]
-disable=too-many-ancestors,too-many-locals,too-few-public-methods,inconsistent-return-statements
+# https://docs.pylint.org/en/latest/technical_reference/features.html
 
-# Maximum number of arguments for function / method
-max-args=9
-max-attributes=8
+[MESSAGES CONTROL]
+
+# Maximum number of parents for a class.
+# The default of 7 results in "too-many-ancestors" for all bidict classes.
+max-parents = 12
+
+# Maximum number of arguments for a function.
+# The default of 5 only leaves room for 4 args besides self for methods.
+max-args=6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,22 +49,28 @@ Changelog
 Breaking API Changes
 ++++++++++++++++++++
 
-- Rename ``bidict.frozenbidict.fwd_cls`` → ``..._fwdm_cls``.
+- Rename:
+ 
+  - ``bidict.frozenbidict.fwdm`` → ``._fwdm``
+  - ``bidict.frozenbidict.invm`` → ``._invm``
+  - ``bidict.frozenbidict.fwd_cls`` → ``._fwdm_cls``
+  - ``bidict.frozenbidict.inv_cls`` → ``._invm_cls``
+  - ``bidict.frozenbidict.isinv`` → ``._isinv``
 
-- Rename ``bidict.frozenbidict.inv_cls`` → ``..._invm_cls``.
+  Though overriding ``_fwdm_cls`` and ``_invm_cls`` remains supported
+  (see :ref:`extending`),
+  this is not a common enough use case to warrant public names.
+  Most users do not need to know or care about any of these.
 
-- Rename ``bidict.frozenbidict.isinv`` → ``..._isinv``.
-
-- :class:`~bidict.DuplicationPolicy` now just extends :class:`object`
-  (rather than ``bidict._Marker``).
-  And its
-  :attr:`~bidict.DuplicationPolicy.RAISE`,
-  :attr:`~bidict.DuplicationPolicy.OVERWRITE`, and
-  :attr:`~bidict.DuplicationPolicy.IGNORE`
-  attributes now extend ``bidict._Marker``
-  (rather than :class:`~bidict.DuplicationPolicy`).
+- The :attr:`~bidict.RAISE`,
+  :attr:`~bidict.OVERWRITE`, and
+  :attr:`~bidict.IGNORE`
+  duplication policies are no longer available as attributes of
+  :class:`bidict.DuplicationPolicy`,
+  and can now only be accesseed as attributes of
+  the :mod:`bidict` module namespace.
   (So it is no longer possible to create an infinite chain like
-  ``DuplicationPolicy.RAISE.RAISE.RAISE...``.)
+  ``DuplicationPolicy.RAISE.RAISE.RAISE...``)
 
 - :func:`~bidict.namedbidict` now raises :class:`TypeError` if the provided
   ``base_type`` is not a subclass of :class:`~bidict.frozenbidict`.
@@ -118,8 +124,7 @@ Breaking API Changes
 -------------------
 
 - Fix a bug where :class:`~bidict.bidict`\’s
-  default *on_dup_kv* policy was set to
-  :attr:`~bidict.DuplicationPolicy.RAISE`,
+  default *on_dup_kv* policy was set to :attr:`~bidict.RAISE`,
   rather than matching whatever *on_dup_val* policy was in effect
   as was :ref:`documented <key-and-value-duplication>`.
 
@@ -348,15 +353,15 @@ This release includes multiple API simplifications and improvements.
   duplicates any existing item's.
   These can take the following values:
 
-  - :attr:`~bidict.DuplicationPolicy.RAISE`
-  - :attr:`~bidict.DuplicationPolicy.OVERWRITE`
-  - :attr:`~bidict.DuplicationPolicy.IGNORE`
+  - :attr:`~bidict.RAISE`
+  - :attr:`~bidict.OVERWRITE`
+  - :attr:`~bidict.IGNORE`
 
   ``on_dup_kv`` can also take ``ON_DUP_VAL``.
 
   If not provided,
   :func:`~bidict.bidict.put` uses the
-  :attr:`~bidict.DuplicationPolicy.RAISE` policy by default.
+  :attr:`~bidict.RAISE` policy by default.
 
 - New :func:`~bidict.bidict.putall` method
   provides a bulk :func:`~bidict.bidict.put` API,

--- a/bidict/_dup.py
+++ b/bidict/_dup.py
@@ -6,13 +6,18 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-"""Provides bidict duplication behaviors."""
+"""Provides bidict duplication policies and the :class:`_OnDup` class."""
 
+
+from collections import namedtuple
 
 from ._marker import _Marker
 
 
-class DuplicationPolicy(object):
+_OnDup = namedtuple('_OnDup', 'key val kv')
+
+
+class DuplicationPolicy(_Marker):
     """Provides bidict's duplication policies.
 
     See also :ref:`values-must-be-unique`
@@ -20,16 +25,12 @@ class DuplicationPolicy(object):
 
     __slots__ = ()
 
-    #: Raise an exception when a duplication is encountered.
-    RAISE = _Marker('RAISE')
 
-    #: Overwrite an existing item when a duplication is encountered.
-    OVERWRITE = _Marker('OVERWRITE')
+#: Raise an exception when a duplication is encountered.
+RAISE = DuplicationPolicy('DUP_POLICY.RAISE')
 
-    #: Keep the existing item and ignore the new item when a duplication is encountered.
-    IGNORE = _Marker('IGNORE')
+#: Overwrite an existing item when a duplication is encountered.
+OVERWRITE = DuplicationPolicy('DUP_POLICY.OVERWRITE')
 
-
-RAISE = DuplicationPolicy.RAISE
-OVERWRITE = DuplicationPolicy.OVERWRITE
-IGNORE = DuplicationPolicy.IGNORE
+#: Keep the existing item and ignore the new item when a duplication is encountered.
+IGNORE = DuplicationPolicy('DUP_POLICY.IGNORE')

--- a/bidict/_named.py
+++ b/bidict/_named.py
@@ -35,10 +35,10 @@ def namedbidict(typename, keyname, valname, base_type=bidict):
         __slots__ = ()
 
         def _getfwd(self):
-            return self.inv if self._isinv else self  # pylint: disable=protected-access
+            return self.inv if self._isinv else self
 
         def _getinv(self):
-            return self if self._isinv else self.inv  # pylint: disable=protected-access
+            return self if self._isinv else self.inv
 
         def __reduce__(self):
             return (_make_empty, (typename, keyname, valname, base_type), self.__getstate__())

--- a/bidict/_noop.py
+++ b/bidict/_noop.py
@@ -6,14 +6,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-"""Provides :class:`_Marker`, an internal type for representing singletons."""
+"""Provides the :obj:`_NOOP` sentinel, for internally signaling "no-op"."""
 
-from collections import namedtuple
+from ._marker import _Marker
 
 
-class _Marker(namedtuple('_Marker', 'name')):
-
-    __slots__ = ()
-
-    def __repr__(self):
-        return '<%s>' % self.name  # pragma: no cover
+_NOOP = _Marker('NO-OP')

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,13 @@ bidict
 ..  :inherited-members:
 
 
+.. autodata:: bidict.RAISE
+
+.. autodata:: bidict.OVERWRITE
+
+.. autodata:: bidict.IGNORE
+
+
 bidict.compat
 -------------
 

--- a/docs/overwritingbidict.rst.inc
+++ b/docs/overwritingbidict.rst.inc
@@ -4,7 +4,7 @@
 ############################
 
 If you'd like
-:attr:`~bidict.DuplicationPolicy.OVERWRITE`
+:attr:`~bidict.OVERWRITE`
 to be the default duplication policy for
 :func:`~bidict.bidict.__setitem__` and
 :func:`~bidict.bidict.update`,
@@ -43,7 +43,7 @@ simply adapt this recipe to have the class inherit from
 Beware of ``OVERWRITE``
 :::::::::::::::::::::::
 
-With a default :attr:`~bidict.DuplicationPolicy.OVERWRITE` policy
+With a default :attr:`~bidict.OVERWRITE` policy
 as in the ``OverwritingBidict`` recipe above,
 beware of the following potentially surprising behavior::
 

--- a/docs/values-unique.rst.inc
+++ b/docs/values-unique.rst.inc
@@ -113,9 +113,9 @@ These methods allow you to specify different strategies for handling
 key and value duplication via
 the *on_dup_key*, *on_dup_val*, and *on_dup_kv* arguments.
 Three possible options are
-:attr:`~bidict.DuplicationPolicy.RAISE`,
-:attr:`~bidict.DuplicationPolicy.OVERWRITE`, and
-:attr:`~bidict.DuplicationPolicy.IGNORE`::
+:attr:`~bidict.RAISE`,
+:attr:`~bidict.OVERWRITE`, and
+:attr:`~bidict.IGNORE`::
 
     >>> from bidict import RAISE, OVERWRITE, IGNORE
     >>> b = bidict({2: 4})
@@ -139,7 +139,7 @@ the *on_dup_key* and *on_dup_val* keyword arguments of
 and
 :func:`~bidict.bidict.putall`
 default to
-:attr:`~bidict.DuplicationPolicy.RAISE`,
+:attr:`~bidict.RAISE`,
 providing stricter-by-default alternatives to
 :func:`~bidict.bidict.__setitem__`
 and

--- a/tests/test_bidict.txt
+++ b/tests/test_bidict.txt
@@ -155,7 +155,7 @@ Empty update is a no-op::
 
 Not part of the public API, but test this anyway for the coverage::
 
-    >>> bi._update(False, bi.on_dup_key, bi.on_dup_val, bi.on_dup_kv)
+    >>> bi._update(False, None)
     >>> bi
     bidict()
 

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -106,6 +106,7 @@ def test_bidirectional_mappings(B, init):  # noqa
     [(a, m) for (a, ms) in iteritems(mutating_methods_by_arity) for m in ms])
 @pytest.mark.parametrize('B', bidict_types)  # noqa
 @given(init=inititems, arg1=immutable, arg2=immutable, items=itemlists)
+# pylint: disable=too-many-arguments
 def test_consistency_after_mutation(arity, methodname, B, init, arg1, arg2, items):
     """
     Call every mutating method on every bidict type that supports it,

--- a/tests/test_subclasshook.py
+++ b/tests/test_subclasshook.py
@@ -13,7 +13,7 @@ BidirectionalMapping's interface, it is automatically a subclass.
 from bidict import BidirectionalMapping
 
 
-class MyBidirectionalMapping(dict):
+class MyBidirectionalMapping(dict):  # pylint: disable=too-few-public-methods
     """Dummy type implementing the BidirectionalMapping interface."""
 
     def __inverted__(self):
@@ -26,7 +26,7 @@ class MyBidirectionalMapping(dict):
         return MyBidirectionalMapping(self.__inverted__())
 
 
-class OldStyleClass:  # pylint: disable=old-style-class,no-init
+class OldStyleClass:  # pylint: disable=old-style-class,no-init,too-few-public-methods
     """In Python 2 this is an old-style class (not derived from object)."""
 
 


### PR DESCRIPTION
- Refactor _dedup_item, _write_item, and _undo_write methods to use
  higher-level abstractions (_DedupResult and _WriteResult classes).
- Add internal _OnDup class to bundle (on_dup_key, on_dup_val, on_dup_kv)
  together into a single abstraction. Signatures of methods like _put and
  _update are cleaner as a result.
- Add the "_NOOP" _DedupResult abstraction.
- Make _Marker extend namedtuple, no need for it to be mutable.
- Enable the pylint messages that were disabled now that the code is cleaner.
- Make DuplicationPolicy extend _Marker and make RAISE, OVERWRITE, and
  IGNORE instances of DuplicationPolicy once again. This time deprecate
  access via DuplicationPolicy.(IGNORE|RAISE|OVERWRITE) to prevent
  infinite chaining.
- Misc. code and docs improvements.