### PR TITLE
improve BidirectionalMapping.__subclasshook__, .compat, .util->._util, docs, tests, lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
   sha: v2.1.1
   hooks:
   - id: pydocstyle
+    exclude: bidict/_version.py
 
 - repo: git://github.com/Lucas-C/pre-commit-hooks
   sha: v1.1.4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,8 +36,8 @@ Speedups and memory usage improvements
 - Make :func:`bidict.OrderedBidictBase.__iter__` as well as
   equality comparison slightly faster for ordered bidicts.
 
-Minor Bugfix
-++++++++++++
+Minor Bugfixes
+++++++++++++++
 
 - :func:`~bidict.namedbidict` now verifies that the provided
   ``keyname`` and ``valname`` are distinct,
@@ -87,10 +87,11 @@ The following breaking changes are expected to affect few if any users.
   Having e.g. ``issubclass(bidict, frozenbidict) == True`` was confusing,
   so this change restores ``issubclass(bidict, frozenbidict) == False``.
 
-  See the updated :ref:`bidict-types-diagram`.
+  See the updated :ref:`bidict-types-diagram`
+  and :ref:`polymorphism` documentation.
 
 - Rename:
- 
+
   - ``bidict.BidictBase.fwdm`` → ``._fwdm``
   - ``bidict.BidictBase.invm`` → ``._invm``
   - ``bidict.BidictBase.fwd_cls`` → ``._fwdm_cls``
@@ -112,6 +113,11 @@ The following breaking changes are expected to affect few if any users.
   which was the canonical way to refer to them anyway.
   It is now no longer possible to create an infinite chain like
   ``DuplicationPolicy.RAISE.RAISE.RAISE...``
+
+- Make :func:`bidict.pairs` and :func:`bidict.inverted`
+  no longer importable from ``bidict.util``,
+  and now only importable from the top-level :mod:`bidict` module.
+  (``bidict.util`` was renamed ``bidict._util``.)
 
 - Pickling ordered bidicts now requires
   at least version 2 of the pickle protocol.
@@ -448,8 +454,8 @@ This release includes multiple API simplifications and improvements.
   compatibility helpers.
 
 - More efficient implementations of
-  :func:`~bidict.util.pairs`,
-  :func:`~bidict.util.inverted`, and
+  :func:`~bidict.pairs`,
+  :func:`~bidict.inverted`, and
   :func:`~bidict.BidictBase.copy`.
 
 - Implement :func:`~bidict.BidictBase.__copy__`
@@ -601,11 +607,11 @@ Breaking API Changes
   to new :mod:`bidict.compat` module.
 
 - Move :class:`bidict.inverted`
-  to new :mod:`bidict.util` module
+  to new ``bidict.util`` module
   (still available from top-level :mod:`bidict` module as well).
 
 - Move ``bidict.fancy_iteritems``
-  to :func:`bidict.util.pairs`
+  to :func:`bidict.pairs`
   (also available from top level as :func:`bidict.pairs`).
 
 - Rename :func:`bidict.namedbidict`\'s ``bidict_type`` argument ``base_type``.

--- a/bidict/__init__.py
+++ b/bidict/__init__.py
@@ -49,6 +49,7 @@ from ._dup import DuplicationPolicy, IGNORE, OVERWRITE, RAISE
 from ._exc import (
     BidictException, DuplicationError,
     KeyDuplicationError, ValueDuplicationError, KeyAndValueDuplicationError)
+from ._util import pairs, inverted
 from ._frozen import frozenbidict
 from ._frozenordered import FrozenOrderedBidict
 from ._named import namedbidict
@@ -57,7 +58,6 @@ from ._ordered import OrderedBidict
 from .metadata import (
     __author__, __maintainer__, __copyright__, __email__, __credits__,
     __license__, __status__, __description__, __version__)
-from .util import pairs, inverted
 
 
 __all__ = (

--- a/bidict/_base.py
+++ b/bidict/_base.py
@@ -28,7 +28,7 @@
 
 """Provides :class:`BidictBase`."""
 
-from collections import ItemsView, Mapping, namedtuple
+from collections import namedtuple
 from weakref import ref
 
 from ._abc import BidirectionalMapping
@@ -37,8 +37,8 @@ from ._exc import (
     DuplicationError, KeyDuplicationError, ValueDuplicationError, KeyAndValueDuplicationError)
 from ._miss import _MISS
 from ._noop import _NOOP
-from .compat import PY2, iteritems
-from .util import pairs
+from ._util import pairs
+from .compat import PY2, iteritems, ItemsView, Mapping
 
 
 # Since BidirectionalMapping implements __subclasshook__, and BidictBase
@@ -426,7 +426,7 @@ class BidictBase(BidirectionalMapping):
         def viewvalues(self):  # noqa: D102; pylint: disable=missing-docstring
             return self.inv.viewkeys()
         viewvalues.__doc__ = values.__doc__
-        values.__doc__ = "A list of the contained values."
+        values.__doc__ = 'A list of the contained values.'
 
         def viewitems(self):
             """A set-like object providing a view on the contained items."""

--- a/bidict/_frozen.py
+++ b/bidict/_frozen.py
@@ -27,9 +27,8 @@
 
 """Provides :class:`frozenbidict`, an immutable, hashable bidirectional mapping type."""
 
-from collections import ItemsView
-
 from ._base import BidictBase
+from .compat import ItemsView
 
 
 # lgtm [py/missing-equals]

--- a/bidict/_mut.py
+++ b/bidict/_mut.py
@@ -28,11 +28,10 @@
 
 """Provides :class:`_MutableBidict`."""
 
-from collections import MutableMapping
-
 from ._base import BidictBase
 from ._dup import OVERWRITE, RAISE, _OnDup
 from ._miss import _MISS
+from .compat import MutableMapping
 
 
 # Extend MutableMapping explicitly because it doesn't implement __subclasshook__, as well as to

--- a/bidict/_orderedbase.py
+++ b/bidict/_orderedbase.py
@@ -28,12 +28,10 @@
 
 """Provides :class:`OrderedBidictBase`."""
 
-from collections import Mapping
-
 from ._base import _WriteResult, BidictBase
 from ._marker import _Marker
 from ._miss import _MISS
-from .compat import iteritems, izip
+from .compat import iteritems, izip, Mapping
 
 
 _DAT = 0

--- a/bidict/_util.py
+++ b/bidict/_util.py
@@ -8,10 +8,9 @@
 
 """Useful functions for working with bidirectional mappings and related data."""
 
-from collections import Mapping
 from itertools import chain
 
-from .compat import iteritems
+from .compat import iteritems, Mapping
 
 
 def pairs(*args, **kw):

--- a/bidict/compat.py
+++ b/bidict/compat.py
@@ -70,6 +70,8 @@ if PY2:
     itervalues = methodcaller('itervalues')
     iteritems = methodcaller('iteritems')
     from itertools import izip  # pylint: disable=no-name-in-module,unused-import
+    # pylint: disable=unused-import
+    from collections import Mapping, MutableMapping, ItemsView, Hashable  # noqa: F401 (unused)
 
 else:
 
@@ -87,3 +89,5 @@ else:
     itervalues = _compose(iter, viewvalues)
     iteritems = _compose(iter, viewitems)
     izip = zip
+    # pylint: disable=unused-import
+    from collections.abc import Mapping, MutableMapping, ItemsView, Hashable  # noqa: F401 (unused)

--- a/docs/learning-from-bidict.rst
+++ b/docs/learning-from-bidict.rst
@@ -210,7 +210,7 @@ Portability
 ===========
 
 - Python 2 vs. Python 3
-  
+
   - mostly :class:`dict` API changes,
     but also functions like :func:`zip`, :func:`map`, :func:`filter`, etc.
 

--- a/docs/polymorphism.rst.inc
+++ b/docs/polymorphism.rst.inc
@@ -10,11 +10,8 @@ to check whether ``obj`` is a :class:`~collections.abc.Mapping`.
 However, this check is too specific, and will fail for many
 types that implement the :class:`~collections.abc.Mapping` interface::
 
-    >>> try:
-    ...     from collections import ChainMap
-    ... except ImportError:  # not available in Python 2
-    ...     ChainMap = None  # Could try with a Python 2 ChainMap shim if in doubt.
-    >>> issubclass(ChainMap, dict) if ChainMap else False
+    >>> from collections import ChainMap  # (Python 3+) # doctest: +SKIP
+    >>> issubclass(ChainMap, dict)  # doctest: +SKIP
     False
 
 The same is true for all the bidict types::
@@ -29,10 +26,10 @@ is to use the abstract base classes (ABCs)
 from the :mod:`collections` module
 that are provided for this purpose::
 
-    >>> from collections import Mapping
-    >>> issubclass(ChainMap, Mapping) if ChainMap else True
+    >>> from collections import Mapping  # doctest: +SKIP
+    >>> issubclass(ChainMap, Mapping)  # doctest: +SKIP
     True
-    >>> isinstance(bidict(), Mapping)
+    >>> isinstance(bidict(), Mapping)  # doctest: +SKIP
     True
 
 Also note that the proper way to check whether an object
@@ -54,7 +51,7 @@ is an (im)mutable mapping is to use the
 
 Checking for ``isinstance(obj, frozenbidict)`` is too specific
 and could fail in some cases.
-Namely, :class:`~bidict.FrozenOrderedBidict` is an immutable mapping
+For example, :class:`~bidict.FrozenOrderedBidict` is an immutable mapping
 but it does not subclass :class:`~bidict.frozenbidict`::
 
     >>> from bidict import FrozenOrderedBidict
@@ -73,27 +70,18 @@ One thing you might notice is that there is no
 ``Ordered`` or ``OrderedMapping`` ABC.
 However, Python 3.6 introduced the :class:`collections.abc.Reversible` ABC.
 Since being reversible implies having an ordering,
-if you need to check for an ordered mapping,
 you could check for reversibility instead.
 For example::
 
-    >>> def is_reversible(cls):
-    ...     try:
-    ...         from collections import Reversible
-    ...     except ImportError:  # Python < 3.6
-    ...         # Better to use a shim of Python 3.6's Reversible,
-    ...         # but this'll do for now:
-    ...         return getattr(cls, '__reversed__', None) is not None
-    ...     return issubclass(cls, Reversible)
-
-    >>> def is_ordered_mapping(cls):
-    ...     return is_reversible(cls) and issubclass(cls, Mapping)
+    >>> from collections import Reversible  # doctest: +SKIP
+    >>> def is_reversible_mapping(cls):
+    ...     return issubclass(cls, Reversible) and issubclass(cls, Mapping)
     ...
 
     >>> from bidict import OrderedBidict
-    >>> is_ordered_mapping(OrderedBidict)
+    >>> is_reversible_mapping(OrderedBidict)  # doctest: +SKIP
     True
 
     >>> from collections import OrderedDict
-    >>> is_ordered_mapping(OrderedDict)
+    >>> is_ordered_mapping(OrderedDict)  # doctest: +SKIP
     True

--- a/tests/test_class_relationships.py
+++ b/tests/test_class_relationships.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Joshua Bronson. All Rights Reserved.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Test various issubclass checks."""
+
+import pytest
+
+from bidict import bidict, frozenbidict, FrozenOrderedBidict, OrderedBidict, BidirectionalMapping
+from bidict.compat import Mapping, MutableMapping, Hashable
+
+
+class OldStyleClass:  # pylint: disable=old-style-class,no-init,too-few-public-methods
+    """In Python 2 this is an old-style class (not derived from object)."""
+
+
+class AbstractBimap(Mapping):  # pylint: disable=abstract-method
+    """Dummy type that implements the BidirectionalMapping interface
+    without explicitly extending it, and so should still be considered a
+    (virtual) subclass if the BidirectionalMapping ABC is working correctly.
+    (See :meth:`bidict.BidirectionalMapping.__subclasshook__`.)
+
+    (Not actually a *working* BidirectionalMapping implementation,
+    but doesn't need to be for the purposes of this test.)
+    """
+
+    inv = NotImplemented
+
+
+BIDICT_TYPES = (bidict, frozenbidict, FrozenOrderedBidict, OrderedBidict)
+BIMAP_TYPES = BIDICT_TYPES + (AbstractBimap,)
+NOT_BIMAP_TYPES = (dict, object, OldStyleClass)
+MUTABLE_BIDICT_TYPES = (bidict, OrderedBidict)
+HASHABLE_BIDICT_TYPES = (frozenbidict, FrozenOrderedBidict)
+ORDERED_BIDICT_TYPES = (OrderedBidict, FrozenOrderedBidict)
+
+
+@pytest.mark.parametrize('cls', BIMAP_TYPES + NOT_BIMAP_TYPES)
+def test_issubclass_bimap(cls):
+    """Ensure all bidict types are :class:`bidict.BidirectionalMapping`s,
+    as well as AbstractBimap (via __subclasshook__).
+    """
+    is_bimap = issubclass(cls, BidirectionalMapping)
+    assert cls in BIMAP_TYPES if is_bimap else NOT_BIMAP_TYPES
+
+
+@pytest.mark.parametrize('bi_cls', BIDICT_TYPES)
+def test_issubclass_mapping(bi_cls):
+    """Ensure all bidict types are :class:`collections.abc.Mapping`s."""
+    assert issubclass(bi_cls, Mapping)
+
+
+@pytest.mark.parametrize('bi_cls', MUTABLE_BIDICT_TYPES)
+def test_issubclass_mutablemapping(bi_cls):
+    """Ensure all mutable bidict types are :class:`collections.abc.MutableMapping`s."""
+    assert issubclass(bi_cls, MutableMapping)
+
+
+@pytest.mark.parametrize('bi_cls', HASHABLE_BIDICT_TYPES)
+def test_issubclass_hashable(bi_cls):
+    """Ensure all hashable bidict types implement :class:`collections.abc.Hashable`."""
+    assert issubclass(bi_cls, Hashable)
+
+
+@pytest.mark.parametrize('bi_cls', ORDERED_BIDICT_TYPES)
+def test_ordered_reversible(bi_cls):
+    """Ensure all ordered bidict types are reversible."""
+    assert callable(bi_cls.__reversed__)
+
+
+def test_issubclass_internal():
+    """The docs specifically recommend using ABCs
+    over concrete classes when checking whether an interface is provided
+    (see :ref:`polymorphism`).
+    The relationships tested here are not guaranteed to hold in the future,
+    but are still tested so that any unintentional changes won't go unnoticed.
+    """
+    assert issubclass(OrderedBidict, bidict)
+    assert not issubclass(frozenbidict, bidict)
+    assert not issubclass(FrozenOrderedBidict, bidict)
+
+    assert not issubclass(bidict, frozenbidict)
+    assert not issubclass(OrderedBidict, FrozenOrderedBidict)
+
+    assert not issubclass(FrozenOrderedBidict, frozenbidict)
+    assert not issubclass(FrozenOrderedBidict, OrderedBidict)


### PR DESCRIPTION
- Implement BidirectionalMapping.__subclasshook__ in terms of
  Mapping.__subclasshook__ to simplify and correct its implementation.
- Add new test_class_relationships.py tests.
- Import collections ABCs from .compat. Importing them directly from
  collections was deprecated and will stop working in Python 3.8.
  In Python 2 collections.abc does not exist.
- rename util.py -> _util.py