### PR TITLE
ordered bidict code and memory usage improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,11 +22,30 @@ Tip: `Subscribe to bidict releases <https://libraries.io/pypi/bidict>`__
 on libraries.io to be notified when new versions of bidict are released.
 
 
-0.16.1 (not yet released)
+0.17.0 (not yet released)
 -------------------------
 
-Add :attr:`bidict.__version_info__` attribute
-to complement :attr:`bidict.__version__`.
+:class:`~bidict.OrderedBidict` Improvements
++++++++++++++++++++++++++++++++++++++++++++
+
+- Use weakrefs in the linked lists that back
+  :class:`~bidict.OrderedBidict`\s
+  to avoid creating strong reference cycles.
+
+  Memory for an ordered bidict that you create
+  can now be reclaimed in CPython
+  as soon as you no longer hold any references to it,
+  rather than having to wait until the next garbage collection.
+  `#71 <https://github.com/jab/bidict/pull/71>`__
+
+- Internal code improvements and micro-optimizations.
+
+
+Misc
+++++
+
+- Add :attr:`bidict.__version_info__` attribute
+  to complement :attr:`bidict.__version__`.
 
 
 0.16.0 (2018-04-06)
@@ -63,7 +82,8 @@ Speedups and memory usage improvements
 - Use weakrefs to refer to a bidict's inverse internally,
   no longer creating a strong reference cycle.
   Memory for a bidict that you create can now be reclaimed
-  in CPython as soon as you no longer hold any references to it.
+  in CPython as soon as you no longer hold any references to it,
+  rather than having to wait for the next garbage collection.
   See the new
   :ref:`addendum:\:attr\:\`~bidict.BidictBase.inv\` Avoids Reference Cycles`
   documentation.

--- a/bidict/_abc.py
+++ b/bidict/_abc.py
@@ -52,7 +52,7 @@ class BidirectionalMapping(Mapping):  # pylint: disable=abstract-method,no-init
     def inv(self):
         """The inverse of this bidirectional mapping instance.
 
-        See also :attr:`bidict.BidictBase.inv`
+        *See also* :attr:`bidict.BidictBase.inv`
 
         :raises NotImplementedError: Meant to be overridden in subclasses.
         """
@@ -74,7 +74,8 @@ class BidirectionalMapping(Mapping):  # pylint: disable=abstract-method,no-init
         Providing this default implementation enables external functions,
         particularly :func:`~bidict.inverted`, to use this optimized
         implementation when available, instead of having to invert on the fly.
-        See also :func:`bidict.inverted`
+
+        *See also* :func:`bidict.inverted`
         """
         return iteritems(self.inv)
 

--- a/bidict/_dup.py
+++ b/bidict/_dup.py
@@ -20,7 +20,7 @@ _OnDup = namedtuple('_OnDup', 'key val kv')
 class DuplicationPolicy(_Marker):
     """Provides bidict's duplication policies.
 
-    See also :ref:`basic-usage:Values Must Be Unique`.
+    *See also* :ref:`basic-usage:Values Must Be Unique`
     """
 
     __slots__ = ()

--- a/bidict/_named.py
+++ b/bidict/_named.py
@@ -29,7 +29,7 @@ def namedbidict(typename, keyname, valname, base_type=bidict):
     and access to themselves
     via the custom *valname*\_for property.
 
-    See also the :ref:`namedbidict usage documentation
+    *See also* the :ref:`namedbidict usage documentation
     <other-bidict-types:\:func\:\`~bidict.namedbidict\`>`
 
     :raises ValueError: if any of the *typename*, *keyname*, or *valname*

--- a/bidict/_ordered.py
+++ b/bidict/_ordered.py
@@ -29,7 +29,7 @@
 """Provides :class:`OrderedBidict`."""
 
 from ._bidict import bidict
-from ._orderedbase import _END, _NXT, _PRV, OrderedBidictBase
+from ._orderedbase import OrderedBidictBase
 
 
 class OrderedBidict(OrderedBidictBase, bidict):
@@ -43,7 +43,7 @@ class OrderedBidict(OrderedBidictBase, bidict):
         """Remove all items."""
         self._fwdm.clear()
         self._invm.clear()
-        self._sntl[:] = [_END, self._sntl, self._sntl]
+        self._sntl.nxt = self._sntl.prv = self._sntl
 
     def popitem(self, last=True):  # pylint: disable=arguments-differ
         u"""*x.popitem() → (k, v)*
@@ -67,20 +67,19 @@ class OrderedBidict(OrderedBidictBase, bidict):
         :raises KeyError: if the key does not exist
         """
         node = self._fwdm[key]
-        _, prv, nxt = node
-        prv[_NXT] = nxt
-        nxt[_PRV] = prv
+        node.prv.nxt = node.nxt
+        node.nxt.prv = node.prv
         sntl = self._sntl
         if last:
-            last = sntl[_PRV]
-            node[_PRV] = last
-            node[_NXT] = sntl
-            sntl[_PRV] = last[_NXT] = node
+            last = sntl.prv
+            node.prv = last
+            node.nxt = sntl
+            sntl.prv = last.nxt = node
         else:
-            frst = sntl[_NXT]
-            node[_PRV] = sntl
-            node[_NXT] = frst
-            sntl[_NXT] = frst[_PRV] = node
+            first = sntl.nxt
+            node.prv = sntl
+            node.nxt = first
+            sntl.nxt = first.prv = node
 
 
 #                             * Code review nav *

--- a/bidict/_orderedbase.py
+++ b/bidict/_orderedbase.py
@@ -28,16 +28,87 @@
 
 """Provides :class:`OrderedBidictBase`."""
 
+from itertools import chain
+from weakref import ref
+
 from ._base import _WriteResult, BidictBase
-from ._marker import _Marker
 from ._miss import _MISS
-from .compat import iteritems, izip, Mapping
+from .compat import Mapping, iteritems, izip
 
 
-_DAT = 0
-_PRV = 1
-_NXT = 2
-_END = _Marker('END')
+class _Node(object):  # pylint: disable=too-few-public-methods
+    """A node in a circular doubly-linked list
+    that stores the items in an ordered bidict.
+
+    Only weak references to the next and previous nodes
+    are held to avoid creating strong reference cycles.
+    """
+
+    __slots__ = ('item', '_prv', '_nxt', '__weakref__')
+
+    def __init__(self, item, prv, nxt):
+        self.item = item
+        self._setprv(prv)
+        self._setnxt(nxt)
+
+    def __repr__(self):  # pragma: no cover - just useful for debugging
+        return '%s(%s, prv=%s, nxt=%s)' % (
+            self.__class__.__name__, self.item, self.prv.item, self.nxt.item)
+
+    def _getprv(self):
+        return self._prv() if isinstance(self._prv, ref) else self._prv
+
+    def _setprv(self, prv):
+        self._prv = prv and ref(prv)
+
+    prv = property(_getprv, _setprv)
+
+    def _getnxt(self):
+        return self._nxt() if isinstance(self._nxt, ref) else self._nxt
+
+    def _setnxt(self, nxt):
+        self._nxt = nxt and ref(nxt)
+
+    nxt = property(_getnxt, _setnxt)
+
+
+def _make_sentinel():
+    """Create a special node that initially represents a new empty circular linked list,
+    i.e. its next and previous references point back to itself.
+    """
+    sntl = _Node(None, None, None)
+    sntl.nxt = sntl.prv = sntl
+    return sntl
+
+
+def _iter_nodes(sntl, reverse=False):
+    """Given a sentinel node of a linked list,
+    iterate over the remaining nodes in the order specified by *reverse*.
+    """
+    attr = 'prv' if reverse else 'nxt'
+    node = getattr(sntl, attr)
+    while node is not sntl:  # lgtm [py/comparison-using-is]
+        yield node
+        node = getattr(node, attr)
+
+
+def _convert_refs(sntl, weak_to_strong=True):
+    """Converts the weakrefs in a linked list to strong refs, or vice versa.
+    Used below by OrderedBidictBase.__getstate__ to enable pickling (weakrefs can't be pickled)
+    and __setstate__ when unpickling to restore weakrefs.
+    """
+    # pylint: disable=protected-access
+    for node in chain((sntl,), _iter_nodes(sntl)):
+        prvweak = isinstance(node._prv, ref)
+        nxtweak = isinstance(node._nxt, ref)
+        if prvweak and weak_to_strong:
+            node._prv = node._prv()
+        elif not prvweak and not weak_to_strong:
+            node._prv = ref(node._prv)
+        if nxtweak and weak_to_strong:
+            node._nxt = node._nxt()
+        elif not nxtweak and not weak_to_strong:
+            node._nxt = ref(node._nxt)
 
 
 class OrderedBidictBase(BidictBase):  # lgtm [py/missing-equals]
@@ -53,24 +124,17 @@ class OrderedBidictBase(BidictBase):  # lgtm [py/missing-equals]
         The order in which items are inserted is remembered,
         similar to :class:`collections.OrderedDict`.
         """
-        # Sentinel node for the backing linked list that stores the items in order.
-        # Implemented as a circular doubly-linked list.
-        # A linked list node (including the sentinel node) is represented
-        # via a 3-element list, `[data, prev_node, next_node]`, for efficiency
-        # (hence the constant `_PRV` and `_NXT` indices above).
-        # `data` is a pair containing the key and value of an item
-        # in an arbitrary order, i.e. (`key_or_val`, `val_or_key`).
         self._sntl = _make_sentinel()
 
         # Like unordered bidicts, ordered bidicts also store
         # two backing one-directional mappings `fwdm` and `invm`.
-        # But rather than mapping key→val and val→key (respectively),
-        # they map key→node and val→node (respectively),
-        # where the node is the same when key and val are associated with one another.
+        # But rather than mapping key to val and val to key (respectively),
+        # they map key to node and val to node (respectively),
+        # where `node` is the same when key and val are associated with one another.
         # To effect this difference, _write_item and _undo_write are overridden.
         # But much of the rest of BidictBase's implementation,
         # including BidictBase.__init__ and BidictBase._update,
-        # are inherited and reused without modification. Code reuse ftw.
+        # are inherited and able to be reused without modification.
         super(OrderedBidictBase, self).__init__(*args, **kw)
 
     def _init_inv(self):
@@ -81,17 +145,18 @@ class OrderedBidictBase(BidictBase):  # lgtm [py/missing-equals]
     def copy(self):
         """A shallow copy of this ordered bidict."""
         # Fast copy implementation bypassing __init__. See comments in :meth:`BidictBase.copy`.
-        copy = object.__new__(self.__class__)
+        copy = self.__class__.__new__(self.__class__)
         sntl = _make_sentinel()
-        fwdm = {}
-        invm = {}
+        fwdm = dict.fromkeys(self._fwdm)
+        invm = dict.fromkeys(self._invm)
         cur = sntl
-        nxt = sntl[_NXT]
-        for (key, val) in iteritems(self):
-            nxt = [(key, val), cur, sntl]
-            cur[_NXT] = fwdm[key] = invm[val] = nxt
+        nxt = sntl.nxt
+        for item in iteritems(self):
+            nxt = _Node(item, cur, sntl)
+            key, val = item
+            cur.nxt = fwdm[key] = invm[val] = nxt
             cur = nxt
-        sntl[_PRV] = nxt
+        sntl.prv = nxt
         copy._sntl = sntl  # pylint: disable=protected-access
         copy._fwdm = fwdm  # pylint: disable=protected-access
         copy._invm = invm  # pylint: disable=protected-access
@@ -100,57 +165,51 @@ class OrderedBidictBase(BidictBase):  # lgtm [py/missing-equals]
 
     def __getitem__(self, key):
         nodefwd = self._fwdm[key]
-        datafwd = nodefwd[_DAT]
-        val = _get_other(datafwd, key)
+        val = nodefwd.item[not self._isinv]
         nodeinv = self._invm[val]
         assert nodeinv is nodefwd
         return val
 
     def _pop(self, key):
         nodefwd = self._fwdm.pop(key)
-        datafwd, prv, nxt = nodefwd
-        val = _get_other(datafwd, key)
+        val = nodefwd.item[not self._isinv]
         nodeinv = self._invm.pop(val)
         assert nodeinv is nodefwd
-        prv[_NXT] = nxt
-        nxt[_PRV] = prv
-        del nodefwd[:]
+        nodefwd.prv.nxt = nodefwd.nxt
+        nodefwd.nxt.prv = nodefwd.prv
         return val
 
-    @staticmethod
-    def _isdupitem(key, val, dedup_result):
+    def _isdupitem(self, key, val, dedup_result):
         """Return whether (key, val) duplicates an existing item."""
         isdupkey, isdupval, nodeinv, nodefwd = dedup_result
         isdupitem = nodeinv is nodefwd
         if isdupitem:
             assert isdupkey
             assert isdupval
-            data = nodefwd[_DAT]
-            assert key in data
-            assert val in data
+            assert nodefwd.item == ((val, key) if self._isinv else (key, val))
         return isdupitem
 
     def _write_item(self, key, val, dedup_result):  # pylint: disable=too-many-locals
         fwdm = self._fwdm
         invm = self._invm
+        isinv = self._isinv
+        nodeitem = (val, key) if isinv else (key, val)
         isdupkey, isdupval, nodeinv, nodefwd = dedup_result
         if not isdupkey and not isdupval:
             sntl = self._sntl
-            last = sntl[_PRV]
-            node = [(key, val), last, sntl]
-            sntl[_PRV] = last[_NXT] = fwdm[key] = invm[val] = node
+            last = sntl.prv
+            node = _Node((key, val), last, sntl)
+            last.nxt = sntl.prv = fwdm[key] = invm[val] = node
             oldkey = oldval = _MISS
         elif isdupkey and isdupval:
-            datafwd = nodefwd[_DAT]
-            oldval = _get_other(datafwd, key)
-            datainv, invprv, invnxt = nodeinv
-            oldkey = _get_other(datainv, val)
+            oldval = (nodeinv if isinv else nodefwd).item[1]
+            oldkey = (nodefwd if isinv else nodeinv).item[0]
             assert oldkey != key
             assert oldval != val
             # We have to collapse nodefwd and nodeinv into a single node, i.e. drop one of them.
             # Drop nodeinv, so that the item with the same key is the one overwritten in place.
-            invprv[_NXT] = invnxt
-            invnxt[_PRV] = invprv
+            nodeinv.prv.nxt = nodeinv.nxt
+            nodeinv.nxt.prv = nodeinv.prv
             # Don't remove nodeinv's references to its neighbors since
             # if the update fails, we'll need them to undo this write.
             # Python's garbage collector should still be able to detect when
@@ -162,25 +221,23 @@ class OrderedBidictBase(BidictBase):  # lgtm [py/missing-equals]
             assert tmp is nodefwd
             fwdm[key] = invm[val] = nodefwd
             # Update nodefwd with new item.
-            nodefwd[_DAT] = (key, val)
+            nodefwd.item = nodeitem
         elif isdupkey:
-            datafwd = nodefwd[_DAT]
-            oldval = _get_other(datafwd, key)
+            oldval = (nodeinv if isinv else nodefwd).item[1]
             oldkey = _MISS
             oldnodeinv = invm.pop(oldval)
             assert oldnodeinv is nodefwd
             invm[val] = nodefwd
             node = nodefwd
         else:  # isdupval
-            datainv = nodeinv[_DAT]
-            oldkey = _get_other(datainv, val)
+            oldkey = (nodefwd if isinv else nodeinv).item[0]
             oldval = _MISS
             oldnodefwd = fwdm.pop(oldkey)
             assert oldnodefwd is nodeinv
             fwdm[key] = nodeinv
             node = nodeinv
         if isdupkey ^ isdupval:
-            node[_DAT] = (key, val)
+            node.item = nodeitem
         return _WriteResult(key, val, oldkey, oldval)
 
     def _undo_write(self, dedup_result, write_result):  # pylint: disable=too-many-locals
@@ -191,22 +248,21 @@ class OrderedBidictBase(BidictBase):  # lgtm [py/missing-equals]
         if not isdupkey and not isdupval:
             self._pop(key)
         elif isdupkey and isdupval:
-            # datainv was never changed so should still have the original item.
-            datainv, invprv, invnxt = nodeinv
-            assert datainv == (val, oldkey) or datainv == (oldkey, val)
+            # nodeinv.item was never changed, so it should still have its original item.
+            assert nodeinv.item == (oldkey, val)
             # Restore original items.
-            nodefwd[_DAT] = (key, oldval)
-            invprv[_NXT] = invnxt[_PRV] = nodeinv
+            nodefwd.item = (key, oldval)
+            nodeinv.prv.nxt = nodeinv.nxt.prv = nodeinv
             fwdm[oldkey] = invm[val] = nodeinv
             invm[oldval] = fwdm[key] = nodefwd
         elif isdupkey:
-            nodefwd[_DAT] = (key, oldval)
+            nodefwd.item = (key, oldval)
             tmp = invm.pop(val)
             assert tmp is nodefwd
             invm[oldval] = nodefwd
             assert fwdm[key] is nodefwd
         else:  # isdupval
-            nodeinv[_DAT] = (oldkey, val)
+            nodeinv.item = (oldkey, val)
             tmp = fwdm.pop(key)
             assert tmp is nodeinv
             fwdm[oldkey] = nodeinv
@@ -214,17 +270,9 @@ class OrderedBidictBase(BidictBase):  # lgtm [py/missing-equals]
 
     def __iter__(self, reverse=False):
         """An iterator over this bidict's items in order."""
-        fwdm = self._fwdm
-        sntl = self._sntl
-        nextidx = _PRV if reverse else _NXT
-        cur = sntl[nextidx]
-        while cur is not sntl:  # lgtm [py/comparison-using-is]
-            data = cur[_DAT]
-            korv = data[0]
-            node = fwdm.get(korv)
-            key = korv if node is cur else data[1]
-            yield key
-            cur = cur[nextidx]
+        idx = self._isinv
+        for node in _iter_nodes(self._sntl, reverse=reverse):
+            yield node.item[idx]
 
     def __reversed__(self):
         """An iterator over this bidict's items in reverse order."""
@@ -234,7 +282,7 @@ class OrderedBidictBase(BidictBase):  # lgtm [py/missing-equals]
     def equals_order_sensitive(self, other):
         """Order-sensitive equality check.
 
-        See also :ref:`eq-order-insensitive`
+        *See also* :ref:`eq-order-insensitive`
         """
         if not isinstance(other, Mapping) or len(self) != len(other):
             return False
@@ -244,19 +292,25 @@ class OrderedBidictBase(BidictBase):  # lgtm [py/missing-equals]
         """See :meth:`bidict.BidictBase.__repr_delegate__`."""
         return list(iteritems(self))
 
+    def __getstate__(self):
+        """Overrides :attr:`bidict.BidictBase.__getstate__`
+        to convert the additional weakrefs in the backing linked list
+        to strong refs so that instances can be pickled.
 
-def _make_sentinel():
-    sntl = []
-    sntl[:] = [_END, sntl, sntl]
-    return sntl
+        *See also* :meth:`object.__getstate__`
+        """
+        state = super(OrderedBidictBase, self).__getstate__()
+        # weakrefs can't be pickled
+        _convert_refs(state['_sntl'], weak_to_strong=True)
+        return state
 
-
-def _get_other(nodedata, key_or_val):
-    first, second = nodedata
-    if key_or_val == first:
-        return second
-    assert key_or_val == second
-    return first
+    def __setstate__(self, state):
+        """Overrides :attr:`bidict.BidictBase.__setstate__`
+        so that any strong refs in the backing linked list that were converted during pickling
+        can be converted back to weakrefs to avoid creating reference cycles.
+        """
+        super(OrderedBidictBase, self).__setstate__(state)
+        _convert_refs(state['_sntl'], weak_to_strong=False)
 
 
 #                             * Code review nav *

--- a/bidict/_util.py
+++ b/bidict/_util.py
@@ -53,7 +53,7 @@ def inverted(arg):
     Otherwise, return an iterator over the items in `arg`,
     inverting each item on the fly.
 
-    See also :attr:`bidict.BidirectionalMapping.__inverted__`
+    *See also* :attr:`bidict.BidirectionalMapping.__inverted__`
     """
     inv = getattr(arg, '__inverted__', None)
     if callable(inv):

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -349,7 +349,7 @@ def test_bidict_isinv(bi_cls):
 # Skip this test on PyPy where reference counting isn't used to free objects immediately. See:
 # http://doc.pypy.org/en/latest/cpython_differences.html#differences-related-to-garbage-collection-strategies
 # "It also means that weak references may stay alive for a bit longer than expected."
-@pytest.mark.skipif(PYPY, reason='objects with 0 refcount not freed immediately on PyPy')
+@pytest.mark.skipif(PYPY, reason='objects with 0 refcount are not freed immediately on PyPy')
 @given(bi_cls=H_BIDICT_TYPES)
 def test_no_reference_cycles(bi_cls):
     """When you delete your last strong reference to a bidict,


### PR DESCRIPTION
Use weakrefs for references to next and previous nodes in the linked lists that back ordered bidicts to avoid creating strong reference cycles. Memory for an ordered bidict that you create can now be reclaimed in CPython as soon as you no longer hold any references to it, rather than having to wait for the next garbage collection.