### PR TITLE
Use less memory in OrderedBidict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,18 @@ Tip: `Subscribe to bidict releases <https://libraries.io/pypi/bidict>`__
 on libraries.io to be notified when new versions of bidict are released.
 
 
+0.17.2 (2018-04-30)
+-------------------
+
+Memory usage improvements
++++++++++++++++++++++++++
+
+- Use less memory in the linked lists that back
+  :class:`~bidict.OrderedBidict`\s
+  by storing node data unpacked
+  rather than in (key, value) tuple objects.
+
+
 0.17.1 (2018-04-28)
 -------------------
 


### PR DESCRIPTION
- Use less memory in the linked lists that back bidict.OrderedBidict by storing node data unpacked rather than in (key, value) tuple objects.
- New _Sentinel subclass of _Node improves over old _make_sentinel code.