### PR TITLE
Remove hypothesis-pytest dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ DOCS_REQS = [SPHINX_REQ]
 
 TEST_REQS = [
     'hypothesis < 4',
-    'hypothesis-pytest < 1',
     'py < 2',
     'pytest < 5',
     'pytest-benchmark >= 3.2.0, < 4',


### PR DESCRIPTION
According to https://pypi.org/project/hypothesis-pytest hypothesis-pytest is deprecated and its functionality is included in hypothesis.

This is needed to include bidict in the nixpkgs package repository because hypothesis-pytest isn't present, see NixOS/nixpkgs#53782