### PR TITLE
Fix assume when generating bidict_and_mapping_from_different_items

### DIFF
--- a/tests/hypothesis/_setup_hypothesis.py
+++ b/tests/hypothesis/_setup_hypothesis.py
@@ -17,8 +17,7 @@ PROFILE_DEFAULT = {
     'max_examples': int(getenv('HYPOTHESIS_MAX_EXAMPLES') or MAX_EXAMPLES_DEFAULT),
     'deadline': None,
     'timeout': unlimited,
-    # Enabling coverage slows down hypothesis.
-    'suppress_health_check': NOCHECK_SLOW if getenv('COVERAGE') else (),
+    'suppress_health_check': NOCHECK_SLOW,
 }
 PROFILE_MORE_EXAMPLES = dict(
     PROFILE_DEFAULT,

--- a/tests/hypothesis/_strategies.py
+++ b/tests/hypothesis/_strategies.py
@@ -179,7 +179,7 @@ def _bidict_and_mapping_from_items(
             assume(map_items_ != bi_items_)
     else:
         map_items_ = draw(map_items)
-        assume(map_items_ != bi_items_)
+        assume(set(map_items_) != set(bi_items_))
     return bi_cls(bi_items_), map_cls(map_items_)
 
 


### PR DESCRIPTION
...and always suppress "slow" health checks (otherwise they're now triggered even without coverage enabled)