### PR TITLE
Abort install if PY2 detected in setup.py (and more followups to #99)

### DIFF
--- a/bidict/__init__.py
+++ b/bidict/__init__.py
@@ -54,9 +54,8 @@ from .compat import PY2, PYMAJOR, PYMINOR
 if PY2:
     raise ImportError('Python 3.5+ is required.')
 
-# Assume Python 3 when not PY2, but explicitly check before showing this warning.
-if PYMAJOR == 3 and PYMINOR < 5:  # pragma: no cover
-    warn('Python 3.4 and below are not supported.')
+if (PYMAJOR, PYMINOR) < (3, 5):  # pragma: no cover
+    warn('This version of bidict is untested on Python < 3.5 and may not work.')
 
 
 # The rest of this file only collects functionality implemented in the rest of the

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,29 @@
 Ref: https://github.com/pypa/sampleproject/blob/master/setup.py
 """
 
+import sys
 from codecs import open as c_open
 from os.path import abspath, dirname, join
+from warnings import warn
 
 from setuptools import setup
+
+
+PY2_ERR = """
+This version of bidict does not support Python 2.
+Either use bidict 0.18.3,
+the last release with Python 2 support,
+or use Python 3.
+
+Also ensure you are using pip >= 9.0.1 to install bidict.
+
+See python3statement.org for more info.
+"""
+
+if sys.version_info < (3,):
+    sys.exit(PY2_ERR)
+elif sys.version_info < (3, 5):
+    warn('This version of bidict is untested on Python < 3.5 and may not work.')
 
 
 CWD = abspath(dirname(__file__))
@@ -125,7 +144,7 @@ setup(
     license=METADATA.__license__,
     packages=['bidict'],
     zip_safe=False,  # Don't zip. (We're zip-safe but prefer not to.)
-    python_requires='>=3.5',
+    python_requires='>=3',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Also loosen `python_requires` to `'>=3'`. And give a better warning for PY3 \< 3.5.