### PR TITLE
Add py.typed file to mark package as annotated (PEP 561)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-# TODO: switch to appveyor for all CI now that windows, linux, and mac (with python) are available?
-# https://www.appveyor.com/docs/build-environment/
-# https://www.appveyor.com/docs/macos-images-software/
-# etc.
-
 language: 'python'
 
 # Default version used for jobs that don't override it.
@@ -67,8 +62,10 @@ script:  # Run the test suite.
       export HYPOTHESIS_GEN_MAX_SIZE="32"
       export HYPOTHESIS_DEADLINE="500"
     fi
-    # Without this, pypy3 with coverage on Travis is too slow to pass reliably.
-    if [[ "$TASK" == "test-linux-pypy3" ]]; then
+    if [[ "$TASK" == "test-pypy3" ]]; then
+      # Without this, pypy3 with setuptools>=50 fails with "SystemError: Parent module 'setuptools' not loaded, cannot perform relative import":
+      export SETUPTOOLS_USE_DISTUTILS="stdlib"
+      # Without these, pypy3 on Travis is too slow to pass Hypothesis' health checks reliably:
       export HYPOTHESIS_MAX_EXAMPLES="50"
       export HYPOTHESIS_GEN_MAX_SIZE="5"
     fi
@@ -102,12 +99,13 @@ matrix:
 
     # Travis runs jobs in the order defined below -> order jobs by priority.
 
-    ## Test suite on Linux with latest CPython and PyPy 2 and 3 -> enable coverage.
+    ## Test suite with latest stable CPython available on Travis. Enable coverage.
     - python: '3.8'
-      env: 'TASK=test-linux-cpython-3.8 COVERAGE=1'
+      env: 'TASK=test-cpython-3.8 COVERAGE=1'
 
+    ## Test suite with latest PyPy3 available on Travis.
     - python: 'pypy3'
-      env: 'TASK=test-linux-pypy3 COVERAGE=1'
+      env: 'TASK=test-pypy3'
 
     ## Make sure there are no relied-on side effects in assert statements.
     - env: 'TASK=test-with-optimization-flag'
@@ -129,26 +127,12 @@ matrix:
       before_install: 'skip'
       script: '(cd docs && make linkcheck)'
 
-    ## Remaining CPython versions on Linux.
+    ## Remaining supported CPython versions.
     - python: '3.7'
-      env: 'TASK=test-linux-cpython-3.7'
+      env: 'TASK=test-cpython-3.7'
 
     - python: '3.6'
-      env: 'TASK=test-linux-cpython-3.6'
-
-    ## Test suite on Mac with latest system Python 3 available in Travis's Mac image.
-    ## Must set `language: generic` for this to work (otherwise Travis attempts to download
-    ## a non-system Python version which fails with a 404). Setting `python: '3.7'` below
-    ## actually has no effect (the Python version comes from the system Python) other than
-    ## to show the right version in the Travis web UI (must keep up-to-date manually).
-    - os: 'osx'
-      language: 'generic'
-      python: '3.7'
-      env: 'TASK=test-mac-cpython-3.7'
-
-    ## Try Travis's new Windows support once it supports Python?
-    ### - env: 'TASK=test-windows-cpython-3.x'
-    ###   os: 'windows'
+      env: 'TASK=test-cpython-3.6'
 
 deploy:
   - provider: 'pypi'
@@ -179,4 +163,4 @@ notifications:
     urls:
       - 'https://webhooks.gitter.im/e/bf64fb45a633c0935b9b'
   email:
-    recipients: 'jab@math.brown.edu'
+    recipients: 'jabronson@gmail.com'

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -63,7 +63,7 @@ Enforcement
 -----------
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may
-be reported by contacting the project team at <jab@math.brown.edu>. All
+be reported by contacting the project team at <jabronson@gmail.com>. All
 complaints will be reviewed and investigated and will result in a
 response that is deemed necessary and appropriate to the circumstances.
 The project team is obligated to maintain confidentiality with regard to

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -117,7 +117,7 @@ Other Ways to Contribute
   :alt: Chip in via Gumroad
 
 .. image:: https://img.shields.io/badge/PayPal-Chip%20in-blue.svg
-  :target: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=jab%40math%2ebrown%2eedu&lc=US&item_name=Support%20bidict&button_subtype=services&currency_code=USD&bn=PP%2dBuyNowBF%3aPaypal%2dBuy%2520a%2520Drink%2dblue%2esvg%3aNonHosted
+  :target: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=jabronson%40gmail%2ecom&lc=US&item_name=Support%20bidict&button_subtype=services&currency_code=USD&bn=PP%2dBuyNowBF%3aPaypal%2dBuy%2520a%2520Drink%2dblue%2esvg%3aNonHosted
   :alt: Chip in via PayPal
 
 .. 2020-1-1: bountysource.com domain expired, commented out here + removed from .github/FUNDING.yml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ include pytest.ini
 include tox.ini
 include docs/_static/custom.css
 include docs/_static/bidict-types-diagram.dot
+include bidict/py.typed
 recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs Makefile

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Status
   as well as for **reading and learning** [#fn-learning]_
 - has **extensive docs and test coverage**
   (including property-based tests and benchmarks)
-  run continuously on all supported Python versions and OSes
+  run continuously on all supported Python versions
 
 
 Note: Python 3 Required
@@ -164,7 +164,7 @@ You can:
 - `star bidict on GitHub <https://github.com/jab/bidict>`__
 - `create an issue <https://github.com/jab/bidict/issues/new?title=Notice+of+Usage&body=I+am+using+bidict+for...>`__
 - leave a message in the `chat room <https://gitter.im/jab/bidict>`__
-- `email me <mailto:jab@math.brown.edu?subject=bidict&body=I%20am%20using%20bidict%20for...>`__
+- `email me <mailto:jabronson@gmail.com?subject=bidict&body=I%20am%20using%20bidict%20for...>`__
 
 
 Changelog

--- a/bidict/metadata.py
+++ b/bidict/metadata.py
@@ -32,7 +32,7 @@ except Exception:  # pragma: no cover
 __author__ = 'Joshua Bronson'
 __maintainer__ = 'Joshua Bronson'
 __copyright__ = 'Copyright 2009-2020 Joshua Bronson'
-__email__ = 'jab@math.brown.edu'
+__email__ = 'jabronson@gmail.com'
 
 # See: ../docs/thanks.rst
 __credits__ = [i.strip() for i in """


### PR DESCRIPTION
At the moment `mypy` tool will give error below, because there is no `py.typed` file inside package. AFAIK bidict is annotated (:tada:), so why not add this file? See [PEP 561](https://www.python.org/dev/peps/pep-0561/#packaging-type-information) for details

```
error: Skipping analyzing 'bidict': found module but no type hints or library stubs  [import]
```