### PR TITLE
Upgrade dependencies.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,8 +51,3 @@ repos:
   #   # Renamed LICENSE_HEADER -> .LICENSE_HEADER to avoid confusing licensee
   #   # (https://github.com/benbalter/licensee - what GitHub uses to detect license)
   #   - --license-filepath=.LICENSE_HEADER
-
-- repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 2.1.4
-  hooks:
-  - id: shellcheck

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,7 +26,7 @@ check-manifest==0.46
     # via -r dev.in
 click==7.1.2
     # via pip-tools
-coverage==5.3.1
+coverage==5.4
     # via
     #   -r tests.in
     #   pytest-cov
@@ -38,7 +38,7 @@ filelock==3.0.12
     # via
     #   tox
     #   virtualenv
-hypothesis==6.0.2
+hypothesis==6.1.0
     # via -r tests.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -56,7 +56,7 @@ markupsafe==1.1.1
     # via jinja2
 nodeenv==1.5.0
     # via pre-commit
-packaging==20.8
+packaging==20.9
     # via
     #   build
     #   pytest
@@ -72,7 +72,7 @@ pluggy==0.13.1
     #   tox
 pprintpp==0.4.0
     # via pytest-icdiff
-pre-commit==2.9.3
+pre-commit==2.10.0
     # via -r dev.in
 py-cpuinfo==7.0.0
     # via pytest-benchmark
@@ -91,7 +91,7 @@ pytest-cov==2.11.1
     # via -r tests.in
 pytest-icdiff==0.5
     # via -r tests.in
-pytest==6.2.1
+pytest==6.2.2
     # via
     #   -r tests.in
     #   pytest-benchmark
@@ -137,9 +137,9 @@ toml==0.10.2
     #   pre-commit
     #   pytest
     #   tox
-tox==3.21.2
+tox==3.21.3
     # via -r dev.in
-urllib3==1.26.2
+urllib3==1.26.3
     # via requests
 virtualenv==20.4.0
     # via

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -22,7 +22,7 @@ jinja2==2.11.2
     # via sphinx
 markupsafe==1.1.1
     # via jinja2
-packaging==20.8
+packaging==20.9
     # via sphinx
 pygments==2.7.4
     # via sphinx
@@ -48,7 +48,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.4
     # via sphinx
-urllib3==1.26.2
+urllib3==1.26.3
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -16,13 +16,13 @@ certifi==2020.12.5
     # via requests
 chardet==4.0.0
     # via requests
-coverage==5.3.1
+coverage==5.4
     # via
     #   -r tests.in
     #   pytest-cov
 docutils==0.16
     # via sphinx
-hypothesis==6.0.2
+hypothesis==6.1.0
     # via -r tests.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -36,7 +36,7 @@ jinja2==2.11.2
     # via sphinx
 markupsafe==1.1.1
     # via jinja2
-packaging==20.8
+packaging==20.9
     # via
     #   pytest
     #   sphinx
@@ -60,7 +60,7 @@ pytest-cov==2.11.1
     # via -r tests.in
 pytest-icdiff==0.5
     # via -r tests.in
-pytest==6.2.1
+pytest==6.2.2
     # via
     #   -r tests.in
     #   pytest-benchmark
@@ -95,7 +95,7 @@ sphinxcontrib-serializinghtml==1.1.4
     # via sphinx
 toml==0.10.2
     # via pytest
-urllib3==1.26.2
+urllib3==1.26.3
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Also remove shellcheck hook which started fail with:

    [ERROR] The hook `shellcheck` specifies `additional_dependencies` but is
    using language `script` which does not install an environment.  Perhaps
    you meant to use a specific language?