### PR TITLE
mv '_hash' slot declaration to classes that use it

### DIFF
--- a/bidict/_base.py
+++ b/bidict/_base.py
@@ -50,7 +50,7 @@ BT = _t.TypeVar('BT', bound='BidictBase')  # typevar for BidictBase.copy
 class BidictBase(BidirectionalMapping[KT, VT]):
     """Base class implementing :class:`BidirectionalMapping`."""
 
-    __slots__ = ['_fwdm', '_invm', '_inv', '_invweak', '_hash', '__weakref__']
+    __slots__ = ['_fwdm', '_invm', '_inv', '_invweak', '__weakref__']
 
     #: The default :class:`~bidict.OnDup`
     #: that governs behavior when a provided item

--- a/bidict/_frozenbidict.py
+++ b/bidict/_frozenbidict.py
@@ -36,7 +36,7 @@ from ._typing import KT, VT
 class frozenbidict(_DelegatingBidict[KT, VT]):
     """Immutable, hashable bidict type."""
 
-    __slots__ = ()
+    __slots__ = ('_hash',)
 
     # Work around lack of support for higher-kinded types in mypy.
     # Ref: https://github.com/python/typing/issues/548#issuecomment-621571821

--- a/bidict/_frozenordered.py
+++ b/bidict/_frozenordered.py
@@ -37,7 +37,7 @@ from ._typing import KT, VT
 class FrozenOrderedBidict(OrderedBidictBase[KT, VT]):
     """Hashable, immutable, ordered bidict type."""
 
-    __slots__ = ()
+    __slots__ = ('_hash',)
     __hash__ = frozenbidict.__hash__
 
     if _t.TYPE_CHECKING:


### PR DESCRIPTION
Move `_hash` slot declaration from `BidictBase` into only the two subclasses that use it (`frozebidict`, `FrozenOrderedBidict`).

* Now space for the `_hash` slot won't be reserved for the `BidictBase` subclasses that don't use it.
* When reading the code for the subclasses that do use `_hash` (e.g. in `_frozenbidict.py`), it's now more obvious that the required `_hash` slot has been declared (rather than having to check ancestor classes defined in other files to make sure).