### PR TITLE
Minor optimization to FrozenOrderedBidict __iter__ and __reversed__

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,11 +24,11 @@ jobs:
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: PyPy3, python: pypy3, os: ubuntu-latest, tox: pypy3}
-          # - {name: Windows, python: '3.9', os: windows-latest, tox: py39}
-          # - {name: Mac, python: '3.9', os: macos-latest, tox: py39}
-          - {name: lint, python: '3.9', os: ubuntu-latest, tox: lint}
+          # - {name: Windows, python: '3.10', os: windows-latest, tox: py39}
+          # - {name: Mac, python: '3.10', os: macos-latest, tox: py39}
+          - {name: lint, python: '3.10', os: ubuntu-latest, tox: lint}
           # Handled by https://docs.readthedocs.io/en/stable/guides/autobuild-docs-for-pull-requests.html
-          # - {name: Docs, python: '3.9', os: ubuntu-latest, tox: docs}
+          # - {name: Docs, python: '3.10', os: ubuntu-latest, tox: docs}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -66,8 +66,8 @@ jobs:
       # https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
-        # coverage only enabled for "py39" env in tox.ini
-        if: matrix.tox == 'py39'
+        # coverage only enabled for "py37" and "py310" envs in tox.ini
+        if: matrix.tox == 'py37' || matrix.tox == 'py310'
         with:
           verbose: true
           fail_ci_if_error: true

--- a/bidict/_base.py
+++ b/bidict/_base.py
@@ -389,7 +389,7 @@ class BidictBase(BidirectionalMapping[KT, VT]):
     # On Python 3.8+, dicts are reversible, so even non-Ordered bidicts can provide an efficient
     # __reversed__ implementation. (On Python < 3.8, they cannot.) Once support is dropped for
     # Python < 3.8, can remove the following if statement to provide __reversed__ unconditionally.
-    if hasattr(_fwdm_cls, '__reversed__'):  # pragma: no cover
+    if hasattr(_fwdm_cls, '__reversed__'):
         def __reversed__(self) -> _t.Iterator[KT]:
             """Iterator over the contained keys in reverse order."""
             return reversed(self._fwdm)  # type: ignore [no-any-return,call-overload]

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,13 @@ skip_missing_interpreters = true
 deps = -r requirements/tests.txt
 commands = ./run_tests.py
 
-# Only enable coverage for py39 by default
-[testenv:py39]
+# Only enable coverage for py37 and py310 by default
+[testenv:py37]
+setenv =
+  PYTEST_ADDOPTS = --cov=bidict --cov-config=.coveragerc --cov-report=xml
+
+# Only enable coverage for py37 and py310 by default
+[testenv:py310]
 setenv =
   PYTEST_ADDOPTS = --cov=bidict --cov-config=.coveragerc --cov-report=xml
 


### PR DESCRIPTION
Also, enable coverage by default for Python 3.7 and 3.10, rather than only 3.9. This way the codecov status check ensures coverage for 3.8+ sensitive code paths.