### PR TITLE
deps

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,8 +22,7 @@ jobs:
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
-          - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
-          - {name: PyPy3, python: pypy3, os: ubuntu-latest, tox: pypy3}
+          - {name: PyPy3, python: pypy-3.7, os: ubuntu-latest, tox: pypy3}
           # - {name: Windows, python: '3.10', os: windows-latest, tox: py39}
           # - {name: Mac, python: '3.10', os: macos-latest, tox: py39}
           - {name: lint, python: '3.10', os: ubuntu-latest, tox: lint}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,14 +14,15 @@ Release Notifications
 .. duplicated in README.rst
    (would use `.. include::` but GitHub doesn't understand it)
 
-.. image:: https://img.shields.io/badge/libraries.io-subscribe-5BC0DF.svg
-   :target: https://libraries.io/pypi/bidict
-   :alt: Follow on libraries.io
-
-Tip: Subscribe to releases
-`on GitHub <https://github.blog/changelog/2018-11-27-watch-releases/>`__ or
-`libraries.io <https://libraries.io/pypi/bidict>`__
+Tip: Watch releases
+`on GitHub <https://github.blog/changelog/2018-11-27-watch-releases/>`__
 to be notified when new versions of ``bidict`` are released.
+
+
+Development
+-----------
+
+- Drop support for Python 3.6, which reached end of life on 2021-12-23.
 
 
 0.21.4 (2021-10-23)

--- a/README.rst
+++ b/README.rst
@@ -161,13 +161,8 @@ Release Notifications
 .. duplicated in CHANGELOG.rst:
    (would use `.. include::` but GitHub doesn't understand it)
 
-.. image:: https://img.shields.io/badge/libraries.io-subscribe-5BC0DF.svg
-   :target: https://libraries.io/pypi/bidict
-   :alt: Follow on libraries.io
-
 Watch releases
-`on GitHub <https://github.blog/changelog/2018-11-27-watch-releases/>`__ or
-`libraries.io <https://libraries.io/pypi/bidict>`__
+`on GitHub <https://github.blog/changelog/2018-11-27-watch-releases/>`__
 to be notified when new versions of bidict are released.
 
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12
     # via sphinx
-astroid==2.8.4
+astroid==2.9.0
     # via pylint
 attrs==21.2.0
     # via
@@ -14,7 +14,7 @@ attrs==21.2.0
     #   pytest
 babel==2.9.1
     # via sphinx
-backports.entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.1
     # via virtualenv
 build==0.7.0
     # via check-manifest
@@ -22,43 +22,43 @@ certifi==2021.10.8
     # via requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via requests
 check-manifest==0.47
     # via -r dev.in
 click==8.0.3
     # via pip-tools
-coverage[toml]==6.1.1
+coverage[toml]==6.2
     # via
     #   -r tests.in
     #   pytest-cov
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
 docutils==0.17.1
     # via sphinx
-filelock==3.3.2
+filelock==3.4.0
     # via
     #   tox
     #   virtualenv
-hypothesis==6.24.1
+hypothesis==6.31.6
     # via
     #   -r lint.in
     #   -r tests.in
 icdiff==2.0.4
     # via pytest-icdiff
-identify==2.3.3
+identify==2.4.0
     # via pre-commit
 idna==3.3
     # via requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
 iniconfig==1.1.1
     # via pytest
-isort==5.10.0
+isort==5.10.1
     # via pylint
-jinja2==3.0.2
+jinja2==3.0.3
     # via sphinx
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 markupsafe==2.0.1
     # via jinja2
@@ -66,7 +66,7 @@ mccabe==0.6.1
     # via pylint
 nodeenv==1.6.0
     # via pre-commit
-packaging==21.2
+packaging==21.3
     # via
     #   build
     #   pytest
@@ -88,7 +88,7 @@ pluggy==1.0.0
     #   tox
 pprintpp==0.4.0
     # via pytest-icdiff
-pre-commit==2.15.0
+pre-commit==2.16.0
     # via
     #   -r dev.in
     #   -r lint.in
@@ -101,9 +101,9 @@ py-cpuinfo==8.0.0
     # via pytest-benchmark
 pygments==2.10.0
     # via sphinx
-pylint==2.11.1
+pylint==2.12.2
     # via -r lint.in
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pytest==6.2.5
     # via
@@ -128,7 +128,7 @@ six==1.16.0
     # via
     #   tox
     #   virtualenv
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
 sortedcollections==2.1.0
     # via -r tests.in
@@ -137,7 +137,7 @@ sortedcontainers==2.4.0
     #   -r tests.in
     #   hypothesis
     #   sortedcollections
-sphinx==4.2.0
+sphinx==4.3.2
     # via
     #   -r docs.in
     #   sphinx-copybutton
@@ -162,7 +162,7 @@ toml==0.10.2
     #   pylint
     #   pytest
     #   tox
-tomli==1.2.2
+tomli==2.0.0
     # via
     #   build
     #   coverage
@@ -175,7 +175,7 @@ virtualenv==20.10.0
     # via
     #   pre-commit
     #   tox
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 wrapt==1.13.3
     # via astroid

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,31 +10,31 @@ babel==2.9.1
     # via sphinx
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via requests
 docutils==0.17.1
     # via sphinx
 idna==3.3
     # via requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
-jinja2==3.0.2
+jinja2==3.0.3
     # via sphinx
 markupsafe==2.0.1
     # via jinja2
-packaging==21.2
+packaging==21.3
     # via sphinx
 pygments==2.10.0
     # via sphinx
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pytz==2021.3
     # via babel
 requests==2.26.0
     # via sphinx
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.2.0
+sphinx==4.3.2
     # via
     #   -r docs.in
     #   sphinx-copybutton

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -4,35 +4,35 @@
 #
 #    pip-compile lint.in
 #
-astroid==2.8.4
+astroid==2.9.0
     # via pylint
 attrs==21.2.0
     # via
     #   hypothesis
     #   pytest
-backports.entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.1
     # via virtualenv
 cfgv==3.3.1
     # via pre-commit
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.3.2
+filelock==3.4.0
     # via virtualenv
-hypothesis==6.24.1
+hypothesis==6.31.6
     # via -r lint.in
-identify==2.3.3
+identify==2.4.0
     # via pre-commit
 iniconfig==1.1.1
     # via pytest
-isort==5.10.0
+isort==5.10.1
     # via pylint
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 mccabe==0.6.1
     # via pylint
 nodeenv==1.6.0
     # via pre-commit
-packaging==21.2
+packaging==21.3
     # via pytest
 platformdirs==2.4.0
     # via
@@ -40,13 +40,13 @@ platformdirs==2.4.0
     #   virtualenv
 pluggy==1.0.0
     # via pytest
-pre-commit==2.15.0
+pre-commit==2.16.0
     # via -r lint.in
 py==1.11.0
     # via pytest
-pylint==2.11.1
+pylint==2.12.2
     # via -r lint.in
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pytest==6.2.5
     # via -r lint.in

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -14,29 +14,29 @@ babel==2.9.1
     # via sphinx
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via requests
-coverage[toml]==6.1.1
+coverage[toml]==6.2
     # via
     #   -r tests.in
     #   pytest-cov
 docutils==0.17.1
     # via sphinx
-hypothesis==6.24.1
+hypothesis==6.31.6
     # via -r tests.in
 icdiff==2.0.4
     # via pytest-icdiff
 idna==3.3
     # via requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
 iniconfig==1.1.1
     # via pytest
-jinja2==3.0.2
+jinja2==3.0.3
     # via sphinx
 markupsafe==2.0.1
     # via jinja2
-packaging==21.2
+packaging==21.3
     # via
     #   pytest
     #   sphinx
@@ -52,7 +52,7 @@ py-cpuinfo==8.0.0
     # via pytest-benchmark
 pygments==2.10.0
     # via sphinx
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pytest==6.2.5
     # via
@@ -70,7 +70,7 @@ pytz==2021.3
     # via babel
 requests==2.26.0
     # via sphinx
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
 sortedcollections==2.1.0
     # via -r tests.in
@@ -79,7 +79,7 @@ sortedcontainers==2.4.0
     #   -r tests.in
     #   hypothesis
     #   sortedcollections
-sphinx==4.2.0
+sphinx==4.3.2
     # via
     #   -r docs.in
     #   sphinx-copybutton
@@ -99,7 +99,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 toml==0.10.2
     # via pytest
-tomli==1.2.2
+tomli==2.0.0
     # via coverage
 urllib3==1.26.7
     # via requests

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
         'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{310,39,38,37,36,py3}
+  py{310,39,38,37,py3}
   lint
   docs
 


### PR DESCRIPTION
- libraries.io killed "subscribe to releases"?
- Upgrade dev dependencies
- Drop support for py36
