### PR TITLE
Remove use of slots from (non-ABC) bidict types.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,9 +22,14 @@ to be notified when new versions of ``bidict`` are released.
 Development
 -----------
 
-- Minor optimizations to ordered bidicts.
-
 - Drop support for Python 3.6, which reached end of life on 2021-12-23.
+
+- Remove the use of slots from (non-ABC) bidict types.
+
+  This better matches the mapping implementations in Python's standard library,
+  and significantly reduces code complexity and maintenance burden.
+  The memory savings conferred by using slots are not noticeable
+  unless you're creating millions of bidict instances anyway.
 
 
 0.21.4 (2021-10-23)

--- a/bidict/_bidict.py
+++ b/bidict/_bidict.py
@@ -37,8 +37,6 @@ from ._typing import KT, VT
 class bidict(_DelegatingBidict[KT, VT], MutableBidict[KT, VT]):
     """Base class for mutable bidirectional mappings."""
 
-    __slots__ = ()
-
     if _t.TYPE_CHECKING:
         @property
         def inverse(self) -> 'bidict[VT, KT]': ...

--- a/bidict/_delegating.py
+++ b/bidict/_delegating.py
@@ -19,8 +19,6 @@ class _DelegatingBidict(BidictBase[KT, VT]):
     Used to override less efficient implementations inherited by :class:`~collections.abc.Mapping`.
     """
 
-    __slots__ = ()
-
     def __iter__(self) -> _t.Iterator[KT]:
         """Iterator over the contained keys."""
         return iter(self._fwdm)

--- a/bidict/_frozenbidict.py
+++ b/bidict/_frozenbidict.py
@@ -35,8 +35,6 @@ from ._typing import KT, VT
 class frozenbidict(_DelegatingBidict[KT, VT]):
     """Immutable, hashable bidict type."""
 
-    __slots__ = ('_hash',)
-
     _hash: int
 
     # Work around lack of support for higher-kinded types in mypy.

--- a/bidict/_frozenordered.py
+++ b/bidict/_frozenordered.py
@@ -47,7 +47,6 @@ class FrozenOrderedBidict(OrderedBidictBase[KT, VT]):
     FrozenOrderedBidict gives you, but with less space overhead.
     """
 
-    __slots__ = ('_hash',)
     __hash__ = frozenbidict.__hash__
 
     if _t.TYPE_CHECKING:

--- a/bidict/_mut.py
+++ b/bidict/_mut.py
@@ -38,8 +38,6 @@ from ._typing import _NONE, KT, VT, VDT, IterItems, MapOrIterItems
 class MutableBidict(BidictBase[KT, VT], MutableBidirectionalMapping[KT, VT]):
     """Base class for mutable bidirectional mappings."""
 
-    __slots__ = ()
-
     if _t.TYPE_CHECKING:
         @property
         def inverse(self) -> 'MutableBidict[VT, KT]': ...

--- a/bidict/_orderedbase.py
+++ b/bidict/_orderedbase.py
@@ -75,15 +75,6 @@ class _Node:
         self.prv = prv
         self.nxt = nxt
 
-    def __getstate__(self) -> _t.Mapping[str, _t.Any]:
-        """Needed to enable pickling due to use of :attr:`__slots__` and weakrefs."""
-        return dict(prv=self.prv, nxt=self.nxt)
-
-    def __setstate__(self, state: _t.Mapping[str, _t.Any]) -> None:
-        """Needed to enable unpickling due to use of :attr:`__slots__` and weakrefs."""
-        self.prv = state['prv']
-        self.nxt = state['nxt']
-
 
 class _SentinelNode(_Node):
     """Special node in a circular doubly-linked list
@@ -118,8 +109,6 @@ class _SentinelNode(_Node):
 
 class OrderedBidictBase(BidictBase[KT, VT]):
     """Base class implementing an ordered :class:`BidirectionalMapping`."""
-
-    __slots__ = ('_sntl',)
 
     _fwdm_cls: _t.Type[MutableBidirectionalMapping[KT, _Node]] = bidict  # type: ignore [assignment]
     _invm_cls: _t.Type[MutableBidirectionalMapping[VT, _Node]] = bidict  # type: ignore [assignment]

--- a/bidict/_orderedbidict.py
+++ b/bidict/_orderedbidict.py
@@ -37,8 +37,6 @@ from ._typing import KT, VT
 class OrderedBidict(OrderedBidictBase[KT, VT], MutableBidict[KT, VT]):
     """Mutable bidict type that maintains items in insertion order."""
 
-    __slots__ = ()
-
     if _t.TYPE_CHECKING:
         @property
         def inverse(self) -> 'OrderedBidict[VT, KT]': ...

--- a/docs/learning-from-bidict.rst
+++ b/docs/learning-from-bidict.rst
@@ -7,7 +7,7 @@ thanks to working on :mod:`bidict`.
 
 If you would like to learn more about any of the topics below,
 you may find `reading bidict's code
-<https://github.com/jab/bidict/blob/main/bidict/__init__.py#L10>`__
+<https://github.com/jab/bidict/blob/main/bidict/__init__.py#L9>`__
 particularly interesting.
 
 I've sought to optimize the code not just for correctness and performance,
@@ -207,10 +207,9 @@ Better memory usage through ``__slots__``
 =========================================
 
 Using :ref:`slots` dramatically reduces memory usage in CPython
-and speeds up attribute access to boot.
+and speeds up attribute access
+when creating many instances of the same class.
 Must be careful with pickling and weakrefs though!
-See `BidictBase.__getstate__()
-<https://github.com/jab/bidict/blob/main/bidict/_base.py>`__.
 
 
 Better memory usage through :mod:`weakref`


### PR DESCRIPTION
Better matches mapping implementations in stdlib collections, and saves considerable complexity and maintenance burden.

Use of slots was originally added in #56.