### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,8 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
       - run: python -m pip install -U pip setuptools wheel
       - name: install dependencies
         run: pip install -r requirements/lint.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,5 @@
 name: Lint
+
 "on":
   push:
     branches:
@@ -8,6 +9,7 @@ name: Lint
   pull_request:
     branches:
       - main
+
 jobs:
   Lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -9,12 +9,12 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
       - run: python -m pip install -U pip setuptools build
       - run: python -m build
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -1,8 +1,10 @@
 name: Release to PyPI
+
 "on":
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+
 jobs:
   Release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-to-test-pypi.yml
+++ b/.github/workflows/release-to-test-pypi.yml
@@ -16,12 +16,12 @@ jobs:
   Release-Test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
       - run: python -m pip install -U pip setuptools build
       - run: python -m build
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,8 @@ name: Test
 
 "on":
   schedule:
-    - cron: "0 11 * * 5"
+    # Every Friday at noon
+    - cron: "0 12 * * 5"
   push:
     branches:
       - main
@@ -11,6 +12,7 @@ name: Test
   pull_request:
     branches:
       - main
+
 jobs:
   Test:
     name: ${{ matrix.pyversion }}
@@ -20,12 +22,12 @@ jobs:
       matrix:
         include:
           # https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#available-versions-of-python-and-pypy
-          - pyversion: '3.11'
+          - pyversion: "3.11"
             enable_coverage: true
-          - pyversion: '3.10'
-          - pyversion: '3.9'
-          - pyversion: '3.8'
-          - pyversion: '3.7'
+          - pyversion: "3.10"
+          - pyversion: "3.9"
+          - pyversion: "3.8"
+          - pyversion: "3.7"
             enable_coverage: true
           - pyversion: pypy-3.9
           - pyversion: pypy-3.8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,15 +33,15 @@ jobs:
           - pyversion: pypy-3.8
           - pyversion: pypy-3.7
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.pyversion }}
           cache: pip
           cache-dependency-path: requirements/tests.txt
       - run: python -m pip install -U pip setuptools wheel tox
       - name: cache .hypothesis dir
-        uses: actions/cache@v3
+        uses: actions/cache@v3.0.11
         with:
           path: .hypothesis
           key: hypothesis|${{ runner.os }}|${{ matrix.pyversion }}
@@ -52,7 +52,7 @@ jobs:
           echo TOX_TESTENV_PASSENV=PYTEST_ADDOPTS >> $GITHUB_ENV
       - run: tox -e py
       - name: Upload coverage to Codecov  # https://github.com/codecov/codecov-action
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.1
         if: matrix.enable_coverage
         with:
           verbose: true

--- a/.github/workflows/update_github_actions.yml
+++ b/.github/workflows/update_github_actions.yml
@@ -1,0 +1,22 @@
+# https://github.com/marketplace/actions/github-actions-version-updater
+
+name: Update GitHub Actions
+
+"on":
+  schedule:
+    # First day of each month at noon
+    - cron: "0 12 1 * *"
+  push:
+    branches:
+      - deps
+
+jobs:
+  Update-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.ACTIONS_VERSION_UPDATER_TOKEN }}
+      - uses: saadmk11/github-actions-version-updater@v0.7.1
+        with:
+          token: ${{ secrets.ACTIONS_VERSION_UPDATER_TOKEN }}

--- a/.github/workflows/update_github_actions.yml
+++ b/.github/workflows/update_github_actions.yml
@@ -14,7 +14,7 @@ jobs:
   Update-GitHub-Actions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           token: ${{ secrets.ACTIONS_VERSION_UPDATER_TOKEN }}
       - uses: saadmk11/github-actions-version-updater@v0.7.1


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.5.1](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.5.1)** on 2022-07-25T15:14:11Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.0.11](https://github.com/actions/cache/releases/tag/v3.0.11)** on 2022-10-13T11:18:20Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.1](https://github.com/codecov/codecov-action/releases/tag/v3.1.1)** on 2022-09-19T15:25:54Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.3.0](https://github.com/actions/setup-python/releases/tag/v4.3.0)** on 2022-10-10T11:36:21Z
