### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -16,7 +16,7 @@ jobs:
       - run: python -m pip install -U pip setuptools build
       - run: python -m build
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@v1.5.2
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-to-test-pypi.yml
+++ b/.github/workflows/release-to-test-pypi.yml
@@ -25,7 +25,7 @@ jobs:
       - run: python -m pip install -U pip setuptools build
       - run: python -m build
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@v1.5.2
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.5.2](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.5.2)** on 2022-11-30T11:04:25Z
