### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,13 +15,13 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-python@v4.3.0
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912
         with:
           python-version: '3.11'
       - run: python -m pip install -U pip setuptools wheel
       - name: install dependencies
         run: pip install -r dev-deps/lint.txt
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
         with:
           extra_args: --verbose

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -9,14 +9,14 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-python@v4.3.0
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912
         with:
           python-version: '3.11'
       - run: python -m pip install -U pip setuptools build
       - run: python -m build
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.6.1
+        uses: pypa/gh-action-pypi-publish@c7f29f7adef1a245bd91520e94867e5c6eedddcc
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-to-test-pypi.yml
+++ b/.github/workflows/release-to-test-pypi.yml
@@ -19,14 +19,14 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-python@v4.3.0
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912
         with:
           python-version: '3.11'
       - run: python -m pip install -U pip setuptools build
       - run: python -m build
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.6.1
+        uses: pypa/gh-action-pypi-publish@c7f29f7adef1a245bd91520e94867e5c6eedddcc
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,15 +36,15 @@ jobs:
           - pyversion: pypy-3.8
           - pyversion: pypy-3.7
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-python@v4.3.0
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912
         with:
           python-version: ${{ matrix.pyversion }}
           cache: pip
           cache-dependency-path: dev-deps/test.txt
       - run: python -m pip install -U pip setuptools wheel tox==4.0.16
       - name: cache .hypothesis dir
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@c1a5de879eb890d062a85ee0252d6036480b1fe2
         with:
           path: .hypothesis
           key: hypothesis|${{ runner.os }}|${{ matrix.pyversion }}
@@ -54,7 +54,7 @@ jobs:
           echo PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --cov=bidict --cov-config=.coveragerc --cov-report=xml" >> "${GITHUB_ENV}"
       - run: tox -e py
       - name: Upload coverage to Codecov  # https://github.com/codecov/codecov-action
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
         if: matrix.enable_coverage
         with:
           verbose: true

--- a/.github/workflows/update_actions.yml
+++ b/.github/workflows/update_actions.yml
@@ -12,12 +12,12 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
         with:
           token: ${{ secrets.ACTIONS_VERSION_UPDATER_TOKEN }}
       # https://github.com/saadmk11/github-actions-version-updater/issues/49#issuecomment-1356182123
       # - uses: saadmk11/github-actions-version-updater@v0.7.1
-      - uses: saadmk11/github-actions-version-updater@safe-dir
+      - uses: saadmk11/github-actions-version-updater@66922a38bf9dfb2afa06dee9592da2d8a158ceec
         with:
           token: ${{ secrets.ACTIONS_VERSION_UPDATER_TOKEN }}
           update_version_with: release-commit-sha


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** added a new **[commit](https://github.com/actions/cache/commit/c1a5de879eb890d062a85ee0252d6036480b1fe2)** to **[v3.2.1](https://github.com/actions/cache/releases/tag/v3.2.1)** Tag on 2022-12-23T06:28:28Z
* **[pre-commit/action](https://github.com/pre-commit/action)** added a new **[commit](https://github.com/pre-commit/action/commit/646c83fcd040023954eafda54b4db0192ce70507)** to **[v3.0.0](https://github.com/pre-commit/action/releases/tag/v3.0.0)** Tag on 2022-06-05T20:02:59Z
* **[actions/setup-python](https://github.com/actions/setup-python)** added a new **[commit](https://github.com/actions/setup-python/commit/5ccb29d8773c3f3f653e1705f474dfaa8a06a912)** to **[v4.4.0](https://github.com/actions/setup-python/releases/tag/v4.4.0)** Tag on 2022-12-22T12:02:09Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** added a new **[commit](https://github.com/saadmk11/github-actions-version-updater/commit/66922a38bf9dfb2afa06dee9592da2d8a158ceec)** to **[v0.7.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.1)** Tag on 2022-10-29T16:36:37Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** added a new **[commit](https://github.com/codecov/codecov-action/commit/d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70)** to **[v3.1.1](https://github.com/codecov/codecov-action/releases/tag/v3.1.1)** Tag on 2022-09-19T15:24:21Z
* **[actions/checkout](https://github.com/actions/checkout)** added a new **[commit](https://github.com/actions/checkout/commit/755da8c3cf115ac066823e79a1e1788f8940201b)** to **[v3.2.0](https://github.com/actions/checkout/releases/tag/v3.2.0)** Tag on 2022-12-12T19:11:05Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** added a new **[commit](https://github.com/pypa/gh-action-pypi-publish/commit/c7f29f7adef1a245bd91520e94867e5c6eedddcc)** to **[v1.6.4](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.6.4)** Tag on 2022-12-07T01:41:32Z
