### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           echo PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --hypothesis-profile=more-examples" >> "${GITHUB_ENV}"
       - run: python -m pip install -U pip setuptools wheel tox==4.0.16
       - name: cache .hypothesis dir
-        uses: actions/cache@c1a5de879eb890d062a85ee0252d6036480b1fe2
+        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
         with:
           path: .hypothesis
           key: hypothesis|${{ runner.os }}|${{ matrix.pyversion }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** added a new **[commit](https://github.com/actions/cache/commit/4723a57e26efda3a62cbde1812113b730952852d)** to **[v3.2.2](https://github.com/actions/cache/releases/tag/v3.2.2)** Tag on 2022-12-27T11:08:40Z
