### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           echo PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --hypothesis-profile=more-examples" >> "${GITHUB_ENV}"
       - run: python -m pip install -U pip setuptools wheel tox==4.2.0
       - name: cache .hypothesis dir
-        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
         with:
           path: .hypothesis
           key: hypothesis|${{ runner.os }}|${{ matrix.pyversion }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** added a new **[commit](https://github.com/actions/cache/commit/69d9d449aced6a2ede0bc19182fadc3a0a42d2b0)** to **[v3.2.6](https://github.com/actions/cache/releases/tag/v3.2.6)** Tag on 2023-02-21T10:02:12Z
