### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,8 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b
         with:
           python-version: '3.11'
       - run: python -m pip install -U pip setuptools wheel

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -9,14 +9,14 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b
         with:
           python-version: '3.11'
       - run: python -m pip install -U pip setuptools build
       - run: python -m build
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@29930c9cf57955dc1b98162d0d8bc3ec80d9e75c
+        uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-to-test-pypi.yml
+++ b/.github/workflows/release-to-test-pypi.yml
@@ -19,14 +19,14 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b
         with:
           python-version: '3.11'
       - run: python -m pip install -U pip setuptools build
       - run: python -m build
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@29930c9cf57955dc1b98162d0d8bc3ec80d9e75c
+        uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
           # - pyversion: pypy-3.9
           # - pyversion: pypy-3.8
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b
         with:
           python-version: ${{ matrix.pyversion }}
           cache: pip
@@ -58,7 +58,7 @@ jobs:
           echo PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --cov=bidict --cov-config=.coveragerc --cov-report=xml" >> "${GITHUB_ENV}"
       - run: tox -e py
       - name: Upload coverage to Codecov  # https://github.com/codecov/codecov-action
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+        uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
         if: matrix.enable_coverage
         with:
           verbose: true

--- a/.github/workflows/update_actions.yml
+++ b/.github/workflows/update_actions.yml
@@ -12,7 +12,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           token: ${{ secrets.ACTIONS_VERSION_UPDATER_TOKEN }}
       - uses: saadmk11/github-actions-version-updater@a7fd643bb3e9c1ef8f5c70bb5b645f5a2a9f395c


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** added a new **[commit](https://github.com/actions/setup-python/commit/57ded4d7d5e986d7296eab16560982c6dd7c923b)** to **[v4.6.0](https://github.com/actions/setup-python/releases/tag/v4.6.0)** Tag on 2023-04-20T12:13:16Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** added a new **[commit](https://github.com/codecov/codecov-action/commit/894ff025c7b54547a9a2a1e9f228beae737ad3c2)** to **[v3.1.3](https://github.com/codecov/codecov-action/releases/tag/v3.1.3)** Tag on 2023-04-20T17:40:20Z
* **[actions/checkout](https://github.com/actions/checkout)** added a new **[commit](https://github.com/actions/checkout/commit/8e5e7e5ab8b370d6c329ec480221332ada57f0ab)** to **[v3.5.2](https://github.com/actions/checkout/releases/tag/v3.5.2)** Tag on 2023-04-13T12:45:33Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** added a new **[commit](https://github.com/pypa/gh-action-pypi-publish/commit/0bf742be3ebe032c25dd15117957dc15d0cfc38d)** to **[v1.8.5](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.5)** Tag on 2023-04-03T15:56:36Z
