### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
         with:
           python-version: '3.12'
       - run: python -m pip install -U pip setuptools wheel

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
         with:
           python-version: '3.12'
       - run: python -m pip install -U pip setuptools build

--- a/.github/workflows/release-to-test-pypi.yml
+++ b/.github/workflows/release-to-test-pypi.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
         with:
           python-version: '3.12'
       - run: python -m pip install -U pip setuptools build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
             deps_subdir: "pypy3.9"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
         with:
           python-version: ${{ matrix.pyversion }}
           cache: pip

--- a/.github/workflows/update_flake_lock.yml
+++ b/.github/workflows/update_flake_lock.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@07b8bcba1b22d847db7ee507180c33e115499665
+        uses: DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@da2fd6f2563fe3e4f2af8be73b864088564e263d
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action)** added a new **[commit](https://github.com/DeterminateSystems/nix-installer-action/commit/cd46bde16ab981b0a7b2dce0574509104543276e)** to **[v9](https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v9)** Tag on 2023-12-04T19:17:47Z
* **[actions/setup-python](https://github.com/actions/setup-python)** added a new **[commit](https://github.com/actions/setup-python/commit/0a5c61591373683505ea898e09a3ea4f39ef2b9c)** to **[v5.0.0](https://github.com/actions/setup-python/releases/tag/v5.0.0)** Tag on 2023-12-05T13:52:09Z
