### PR TITLE
Automate benchmark baseline updates

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ name: benchmark
 env:
   FORCE_COLOR: "1"
   PYTHONHASHSEED: "42"
-  BASELINE_URL: https://github.com/jab/bidict/releases/download/microbenchmarks/GHA-linux-cachegrind-x86_64-CPython-3.12.2-baseline.json
+  BASELINE_RELEASE_TAG: microbenchmarks
 
 jobs:
   benchmark:
@@ -31,47 +31,53 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-      - name: set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with:
-          # Pin to micro-release for better reproducibility.
-          # When upgrading to a new Python version, remember to upload new associated baseline
-          # benchmark results here: https://github.com/jab/bidict/releases/edit/microbenchmarks
-          python-version: '3.12.2'
-      - name: set up cached uv
-        uses: hynek/setup-cached-uv@4300ec2180bc77d705e626a34e381b81a4772c51
-      - name: create and activate virtualenv
+      - name: install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25
+      - name: resolve benchmark metadata
+        id: metadata
         run: |
-          uv sync --only-group=test
-          source .venv/bin/activate
-          echo PATH="$PATH" >> "$GITHUB_ENV"
-      - name: install the version of bidict to benchmark
-        run: |
-          git checkout ${{ github.event.inputs.ref || github.sha }}
-          # install a non-editable version of bidict at the revision under test
-          uv pip install --no-deps .
-          # restore the current revision so we use its version of tests/microbenchmarks.py
-          git checkout ${{ github.sha }}
-          # move aside the 'bidict' subdirectory to make sure we always import the installed version
-          mv -v bidict src
-      - name: download baseline benchmark results
-        run: |
-          curl -L -s -o baseline.json "$BASELINE_URL"
-          line1=$(head -n1 baseline.json)
-          [ "$line1" = "{" ]
+          mapfile -t python_info < <(nix develop .#benchmark --command bash -c "python - <<'PY'
+          import platform
+          print(platform.python_version())
+          print(platform.python_implementation())
+          PY")
+          python_version=${python_info[0]}
+          python_impl=${python_info[1]}
+          python_series=${python_version%.*}
+          arch=$(uname -m)
+          baseline_asset_name="GHA-linux-cachegrind-${arch}-${python_impl}-${python_series}-baseline.json"
+          baseline_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${BASELINE_RELEASE_TAG}/${baseline_asset_name}"
+          {
+            echo "python_version=$python_version"
+            echo "python_series=$python_series"
+            echo "baseline_asset_name=$baseline_asset_name"
+            echo "baseline_url=$baseline_url"
+          } >> "$GITHUB_OUTPUT"
       - name: benchmark and compare to baseline
         run: |
-          ./cachegrind.py pytest -c /dev/null -n0 \
-              --benchmark-autosave \
-              --benchmark-columns=min,rounds,iterations \
-              --benchmark-disable-gc \
-              --benchmark-group-by=name \
-              --benchmark-compare=baseline.json \
-              microbenchmarks.py
+          nix develop .#benchmark --command bash -c '
+            git checkout ${{ github.event.inputs.ref || github.sha }}
+            # install a non-editable version of bidict at the revision under test
+            uv pip install --no-deps .
+            # restore the current revision so we use its version of tests/microbenchmarks.py
+            git checkout ${{ github.sha }}
+            # move aside the '"'"'bidict'"'"' subdirectory to make sure we always import the installed version
+            mv -v bidict src
+            curl -L -s -o baseline.json "${{ steps.metadata.outputs.baseline_url }}"
+            line1=$(head -n1 baseline.json)
+            [ "$line1" = "{" ]
+            ./cachegrind.py pytest -c /dev/null -n0 \
+                --benchmark-autosave \
+                --benchmark-columns=min,rounds,iterations \
+                --benchmark-disable-gc \
+                --benchmark-group-by=name \
+                --benchmark-compare=baseline.json \
+                microbenchmarks.py
+          '
       - name: archive benchmark results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
-          name: microbenchmark results
+          name: microbenchmark results (CPython ${{ steps.metadata.outputs.python_version }})
           path: .benchmarks
           if-no-files-found: error
 

--- a/.github/workflows/update_benchmark_baselines.yml
+++ b/.github/workflows/update_benchmark_baselines.yml
@@ -1,0 +1,122 @@
+name: update benchmark baselines
+
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - flake.lock
+      - flake.nix
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: (optional) ref to benchmark for the new baseline
+        required: false
+
+env:
+  FORCE_COLOR: "1"
+  PYTHONHASHSEED: "42"
+  BASELINE_RELEASE_TAG: microbenchmarks
+
+jobs:
+  update-baselines:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: install valgrind
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05
+        with:
+          packages: valgrind
+      - name: check out source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
+      - name: install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25
+      - name: resolve benchmark metadata
+        id: metadata
+        run: |
+          mapfile -t python_info < <(nix develop .#benchmark --command bash -c "python - <<'PY'
+          import platform
+          print(platform.python_version())
+          print(platform.python_implementation())
+          PY")
+          python_version=${python_info[0]}
+          python_impl=${python_info[1]}
+          python_series=${python_version%.*}
+          arch=$(uname -m)
+          versioned_asset_name="GHA-linux-cachegrind-${arch}-${python_impl}-${python_version}-baseline.json"
+          series_asset_name="GHA-linux-cachegrind-${arch}-${python_impl}-${python_series}-baseline.json"
+          {
+            echo "python_version=$python_version"
+            echo "python_series=$python_series"
+            echo "versioned_asset_name=$versioned_asset_name"
+            echo "series_asset_name=$series_asset_name"
+          } >> "$GITHUB_OUTPUT"
+      - name: benchmark
+        run: |
+          nix develop .#benchmark --command bash -c '
+            uv pip install --no-deps .
+            # Move aside the working tree package so we always import the installed version.
+            mv -v bidict src
+            ./cachegrind.py pytest -c /dev/null -n0 \
+                --benchmark-autosave \
+                --benchmark-columns=min,rounds,iterations \
+                --benchmark-disable-gc \
+                --benchmark-group-by=name \
+                microbenchmarks.py
+          '
+      - name: prepare baseline assets
+        id: assets
+        run: |
+          benchmark_json=$(find .benchmarks -type f -name '*.json' | sort | tail -n1)
+          [ -n "$benchmark_json" ]
+          cp "$benchmark_json" '${{ steps.metadata.outputs.versioned_asset_name }}'
+          cp "$benchmark_json" '${{ steps.metadata.outputs.series_asset_name }}'
+          {
+            echo "benchmark_json=$benchmark_json"
+            echo "versioned_asset_path=${{ github.workspace }}/${{ steps.metadata.outputs.versioned_asset_name }}"
+            echo "series_asset_path=${{ github.workspace }}/${{ steps.metadata.outputs.series_asset_name }}"
+          } >> "$GITHUB_OUTPUT"
+      - name: ensure baseline release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$BASELINE_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            exit 0
+          fi
+          gh release create "$BASELINE_RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title 'baseline microbenchmarks' \
+            --notes 'This tag exists merely so we have somewhere we can store the attached baseline benchmark data.'
+      - name: upload baseline assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$BASELINE_RELEASE_TAG" \
+            '${{ steps.assets.outputs.versioned_asset_path }}' \
+            '${{ steps.assets.outputs.series_asset_path }}' \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+      - name: write summary
+        run: |
+          {
+            echo '### Uploaded benchmark baselines'
+            echo
+            echo '- Python: `${{ steps.metadata.outputs.python_version }}`'
+            echo '- Versioned asset: `${{ steps.metadata.outputs.versioned_asset_name }}`'
+            echo '- Series alias: `${{ steps.metadata.outputs.series_asset_name }}`'
+            echo '- Source benchmark file: `${{ steps.assets.outputs.benchmark_json }}`'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: archive benchmark results
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: microbenchmark baseline results (CPython ${{ steps.metadata.outputs.python_version }})
+          path: |
+            .benchmarks
+            ${{ steps.metadata.outputs.versioned_asset_name }}
+            ${{ steps.metadata.outputs.series_asset_name }}
+          if-no-files-found: error
+
+permissions:
+  contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 .mypy_cache
 .tox
 .venv
+.venv-benchmark
 bidict.egg-info
 build
 _build

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779068653,
-        "narHash": "sha256-VmSyTxjEoQOWHHvXIUFw+KR1gcVe9h8d4MoJgTFigeg=",
+        "lastModified": 1779752891,
+        "narHash": "sha256-93/sih4h/+wYiFeAxun1t6tMNjIBnn+nTQA72e/FuV8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3928961bd45766fec3778a3afe26ca87e4df0ff4",
+        "rev": "4867c86e2c5ee497c707edb1a003480b8c247b7f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,19 @@
             source ".venv/bin/activate"
           '';
         };
+        benchmark = pkgs.mkShell {
+          packages = with pkgs; [
+            python314
+            uv
+          ];
+          shellHook = ''
+            unset VIRTUAL_ENV
+            export UV_PROJECT_ENVIRONMENT=.venv-benchmark
+            export UV_PYTHON="$(command -v python)"
+            uv sync --only-group=test
+            source "$UV_PROJECT_ENVIRONMENT/bin/activate"
+          '';
+        };
         lint = pkgs.mkShell {
           packages = with pkgs; [prek];
         };


### PR DESCRIPTION
## Summary
- run benchmark workflows from the flake-locked Nix environment instead of setup-python
- add a dedicated workflow that refreshes and uploads baseline benchmark assets
- isolate the benchmark virtualenv and update nixpkgs so the benchmark shell resolves to CPython 3.14.4

## Notes
- `update benchmark baselines` cannot be workflow-dispatched until it exists on the default branch
- after this PR merges, the workflow will dogfood itself automatically on the `main` push because `flake.nix` and `flake.lock` changed
- the existing `benchmark.yml` workflow is still disabled remotely and should only be re-enabled after this PR lands