### PR TITLE
Fix benchmark baseline updater on GitHub Actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,7 @@ jobs:
           nix develop .#benchmark --command bash -c '
             git checkout ${{ github.event.inputs.ref || github.sha }}
             # install a non-editable version of bidict at the revision under test
-            uv pip install --no-deps .
+            uv pip install --python "$VIRTUAL_ENV/bin/python" --no-deps .
             # restore the current revision so we use its version of tests/microbenchmarks.py
             git checkout ${{ github.sha }}
             # move aside the '"'"'bidict'"'"' subdirectory to make sure we always import the installed version

--- a/.github/workflows/update_benchmark_baselines.yml
+++ b/.github/workflows/update_benchmark_baselines.yml
@@ -56,7 +56,7 @@ jobs:
       - name: benchmark
         run: |
           nix develop .#benchmark --command bash -c '
-            uv pip install --no-deps .
+            uv pip install --python "$VIRTUAL_ENV/bin/python" --no-deps .
             # Move aside the working tree package so we always import the installed version.
             mv -v bidict src
             ./cachegrind.py pytest -c /dev/null -n0 \

--- a/cachegrind.py
+++ b/cachegrind.py
@@ -61,6 +61,7 @@ def run_with_cachegrind(args_list: list[str]) -> dict[str, int]:
         *DISABLE_ASLR_CMD,
         'valgrind',
         '--tool=cachegrind',
+        '--cache-sim=yes',
         # Set some reasonable L1 and LL values, based on Haswell.
         # Feel free to update, important part is that they are consistent across runs,
         # instead of the default of copying from the current machine.


### PR DESCRIPTION
## Summary
- install bidict into the benchmark virtualenv explicitly inside GitHub Actions
- enable cache simulation in `cachegrind.py` so Valgrind emits the cache-miss counters the benchmark metric needs

## Validation
- `nix develop .#lint --command prek run --all-files --show-diff-on-failure --verbose`
- `nix develop --command pytest -q --benchmark-disable`
- `update benchmark baselines` workflow succeeded on this branch: https://github.com/jab/bidict/actions/runs/26426165672