### PR TITLE
Include benchmark artifacts in uploads

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           name: microbenchmark results (CPython ${{ steps.metadata.outputs.python_version }})
           path: .benchmarks
+          include-hidden-files: true
           if-no-files-found: error
 
 permissions:

--- a/.github/workflows/update_benchmark_baselines.yml
+++ b/.github/workflows/update_benchmark_baselines.yml
@@ -116,6 +116,7 @@ jobs:
             .benchmarks
             ${{ steps.metadata.outputs.versioned_asset_name }}
             ${{ steps.metadata.outputs.series_asset_name }}
+          include-hidden-files: true
           if-no-files-found: error
 
 permissions:


### PR DESCRIPTION
## Summary
- set `include-hidden-files: true` for benchmark artifact uploads
- ensure `.benchmarks` is archived successfully in both benchmark workflows

## Validation
- benchmark workflow succeeded on this branch: https://github.com/jab/bidict/actions/runs/26426858771