### PR TITLE
Refine nix development shells

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,9 +48,10 @@ Making Changes
     to your PATH. This also pins ``uv`` to the flake-provided
     default Python when initializing ``.venv``.
 
-  - Otherwise, manually ensure you have `prek <https://github.com/j178/prek>`__
-    and at least the latest `stable Python version <https://python.org/downloads/>`__
-    installed and on your PATH.
+  - Otherwise, manually ensure you have `uv <https://docs.astral.sh/uv/>`__,
+    `prek <https://github.com/j178/prek>`__, and at least the latest
+    `stable Python version <https://python.org/downloads/>`__ installed
+    and on your PATH.
 
   - Run ``./init_dev_env``
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,7 +45,8 @@ Making Changes
   - If you have `Nix <https://nixos.org>`__, run ``nix develop``
     from within your clone to start a shell where all supported
     Python versions as well as ``prek`` are installed and added
-    to your PATH.
+    to your PATH. This also pins ``uv`` to the flake-provided
+    default Python when initializing ``.venv``.
 
   - Otherwise, manually ensure you have `prek <https://github.com/j178/prek>`__
     and at least the latest `stable Python version <https://python.org/downloads/>`__

--- a/flake.nix
+++ b/flake.nix
@@ -10,41 +10,119 @@
     flake-utils.lib.eachDefaultSystem (system:
     let
       pkgs = import nixpkgs { inherit system; };
-    in {
-      devShells = {
-        default = pkgs.mkShell {
-          packages = with pkgs; [
-            prek
-            python314
-            python313
-            python312
-            python311
-            pypy3
-            uv  # Bootstrap version used to install a possibly-newer version when 'uv sync' is run (via uv.lock)
-          ];
-          shellHook = ''
-            ./init_dev_env
-            source ".venv/bin/activate"
+      lib = pkgs.lib;
+      latestPython = pkgs.python314;
+      commonTools = with pkgs; [prek uv];
+      supportedPythons = with pkgs; [
+        python314
+        python313
+        python312
+        python311
+        pypy3
+      ];
+
+      mkPathPrefix = packages: ''export PATH="${lib.makeBinPath packages}:$PATH"'';
+
+      mkUvShellHook = {
+        packages,
+        python ? null,
+        projectEnv ? null,
+        syncArgs ? null,
+        activate ? false,
+        extraShellHook ? "",
+      }:
+        lib.concatStringsSep "\n" (
+          lib.filter (line: line != "") [
+            (mkPathPrefix packages)
+            (if projectEnv != null then ''export UV_PROJECT_ENVIRONMENT="${projectEnv}"'' else "")
+            (if python != null then ''export UV_PYTHON="${python.interpreter}"'' else "")
+            (if python != null then ''export UV_PYTHON_DOWNLOADS=never'' else "")
+            (if syncArgs != null then "uv sync ${syncArgs}" else "")
+            extraShellHook
+            (if activate && projectEnv != null then ''source "$UV_PROJECT_ENVIRONMENT/bin/activate"'' else "")
+          ]
+        );
+
+      mkUvShell = {
+        python,
+        projectEnv ? null,
+        syncArgs ? null,
+        activate ? false,
+        extraPackages ? [],
+        extraShellHook ? "",
+      }:
+        let
+          packages = commonTools ++ [python] ++ extraPackages;
+        in
+        pkgs.mkShell {
+          inherit packages;
+          shellHook = mkUvShellHook {
+            inherit packages python projectEnv syncArgs activate extraShellHook;
+          };
+        };
+
+      mkTestShell = { python, projectEnv }:
+        mkUvShell {
+          inherit python projectEnv;
+          syncArgs = "--only-group=test";
+          activate = true;
+          extraShellHook = ''
+            uv pip install --python "$UV_PROJECT_ENVIRONMENT/bin/python" --no-deps -e .
           '';
         };
-        benchmark = pkgs.mkShell {
-          packages = with pkgs; [
-            python314
-            uv
-          ];
-          shellHook = ''
-            unset VIRTUAL_ENV
-            export UV_PROJECT_ENVIRONMENT=.venv-benchmark
-            export UV_PYTHON="$(command -v python)"
-            uv sync --only-group=test
-            source "$UV_PROJECT_ENVIRONMENT/bin/activate"
-          '';
+    in {
+      devShells = {
+        default =
+          let
+            packages = commonTools ++ supportedPythons;
+          in
+          pkgs.mkShell {
+            inherit packages;
+            shellHook = mkUvShellHook {
+              inherit packages;
+              python = latestPython;
+              projectEnv = ".venv";
+              activate = true;
+              extraShellHook = ''
+                ./init_dev_env
+              '';
+            };
+          };
+        benchmark = mkUvShell {
+          python = latestPython;
+          projectEnv = ".venv-benchmark";
+          syncArgs = "--only-group=test";
+          activate = true;
+        };
+        build = mkUvShell {
+          python = pkgs.python313;
         };
         lint = pkgs.mkShell {
           packages = with pkgs; [prek];
+          shellHook = mkPathPrefix [pkgs.prek];
         };
-        update_deps = pkgs.mkShell {
-          packages = with pkgs; [prek uv];
+        test311 = mkTestShell {
+          python = pkgs.python311;
+          projectEnv = ".venv-test-3.11";
+        };
+        test312 = mkTestShell {
+          python = pkgs.python312;
+          projectEnv = ".venv-test-3.12";
+        };
+        test313 = mkTestShell {
+          python = pkgs.python313;
+          projectEnv = ".venv-test-3.13";
+        };
+        test314 = mkTestShell {
+          python = pkgs.python314;
+          projectEnv = ".venv-test-3.14";
+        };
+        testPyPy311 = mkTestShell {
+          python = pkgs.pypy3;
+          projectEnv = ".venv-test-pypy3.11";
+        };
+        update_deps = mkUvShell {
+          python = latestPython;
         };
       };
     });

--- a/init_dev_env
+++ b/init_dev_env
@@ -13,7 +13,7 @@ set -euo pipefail
 declare -r hint="Hint: Use 'nix develop' to bootstrap a development environment"
 
 for cmd in uv prek; do
-  if ! type "$cmd"; then
+  if ! command -v "$cmd" >/dev/null 2>&1; then
     >&2 echo "Error: No '$cmd' on PATH. $hint"
     exit 1
   fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dev = [
   "pytest-sugar",
   "tox",
   "tox-uv",
-  "uv",
 ]
 docs = [
   "sphinx",

--- a/update_dev_dependencies
+++ b/update_dev_dependencies
@@ -17,7 +17,7 @@ main() {
   declare -r hint="Hint: Use 'nix develop' to bootstrap a development environment"
 
   for cmd in uv prek; do
-    if ! type "$cmd"; then
+    if ! command -v "$cmd" >/dev/null 2>&1; then
       log "Error: No '$cmd' on PATH. $hint"
       exit 1
     fi

--- a/uv.lock
+++ b/uv.lock
@@ -105,7 +105,6 @@ dev = [
     { name = "pytest-sugar" },
     { name = "tox" },
     { name = "tox-uv" },
-    { name = "uv" },
 ]
 docs = [
     { name = "furo" },
@@ -136,7 +135,6 @@ dev = [
     { name = "pytest-sugar" },
     { name = "tox" },
     { name = "tox-uv" },
-    { name = "uv" },
 ]
 docs = [
     { name = "furo" },


### PR DESCRIPTION
## Summary
- refactor flake.nix to define reusable Python-pinned shells for local dev, testing, builds, and dependency updates
- make the uv-driven shells prefer flake-provided interpreters and tools for reproducibility
- quiet the command-availability checks in the dev setup scripts and note the pinned uv/python behavior in CONTRIBUTING

## Testing
- nix flake show --no-write-lock-file
- nix develop .#build --command uv build
- nix develop .#lint --command bash -c 'prek run --all-files --show-diff-on-failure --verbose'
- nix develop --command tox -e py314,py313,py312,py311,pypy3.11