### PR TITLE
Comment benchmark results on PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -90,6 +90,18 @@ jobs:
           ' 2>&1 | tee benchmark-output.txt
           benchmark_status=${PIPESTATUS[0]}
           echo "exit_code=$benchmark_status" >> "$GITHUB_OUTPUT"
+          if [ "$benchmark_status" -eq 0 ]; then
+            result_state=ok
+            result_message='no threshold-triggering regressions detected'
+          elif grep -Fq 'Performance has regressed:' benchmark-output.txt; then
+            result_state=regression
+            result_message="one or more benchmarks slowed down by at least ${PR_BENCHMARK_COMPARE_FAIL}; workflow kept green because PR benchmarking is informational"
+          else
+            result_state=failed
+            result_message='benchmark execution failed'
+          fi
+          echo "result_state=$result_state" >> "$GITHUB_OUTPUT"
+          echo "result_message=$result_message" >> "$GITHUB_OUTPUT"
           if [ "$benchmark_status" -ne 0 ] && [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "::warning::Benchmark comparison exceeded the informational PR threshold (${PR_BENCHMARK_COMPARE_FAIL}) or the benchmark run failed; see the job summary and artifact for details."
             exit 0
@@ -112,14 +124,62 @@ jobs:
               echo "- PR mode: n/a"
               echo "- Warning threshold: not applied"
             fi
-            if [ "${{ steps.benchmark.outputs.exit_code }}" = "0" ]; then
-              echo "- Result: no threshold-triggering regressions detected"
-            elif [ "${{ github.event_name }}" = "pull_request" ]; then
-              echo "- Result: threshold exceeded or benchmark execution failed; workflow kept green because PR benchmarking is non-blocking"
-            else
-              echo "- Result: benchmark step failed"
-            fi
+            echo "- Result: ${{ steps.benchmark.outputs.result_message }}"
           } >> "$GITHUB_STEP_SUMMARY"
+      - name: prepare PR benchmark comment
+        if: always() && github.event_name == 'pull_request'
+        env:
+          BASELINE_ASSET_NAME: ${{ steps.metadata.outputs.baseline_asset_name }}
+          RESULT_MESSAGE: ${{ steps.benchmark.outputs.result_message }}
+          RESULT_STATE: ${{ steps.benchmark.outputs.result_state }}
+        run: |
+          mkdir -p benchmark-pr-comment
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          case "$RESULT_STATE" in
+            ok)
+              status_line=':white_check_mark: No threshold-triggering regressions detected.'
+              ;;
+            regression)
+              status_line=':warning: Informational benchmark regression detected.'
+              ;;
+            *)
+              status_line=':warning: Benchmark execution failed.'
+              ;;
+          esac
+          cat > benchmark-pr-comment/comment.md <<EOF
+          <!-- bidict-benchmark-comment -->
+          ## Benchmark report
+
+          ${status_line}
+
+          - Baseline asset: \`${BASELINE_ASSET_NAME}\`
+          - Threshold: \`${PR_BENCHMARK_COMPARE_FAIL}\`
+          - Result: ${RESULT_MESSAGE}
+          - Run: [benchmark workflow run](${run_url})
+
+          _This benchmark check is informational and does not block merging._
+          EOF
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = {
+              'result_state': os.environ['RESULT_STATE'],
+              'result_message': os.environ['RESULT_MESSAGE'],
+              'baseline_asset_name': os.environ['BASELINE_ASSET_NAME'],
+              'threshold': os.environ['PR_BENCHMARK_COMPARE_FAIL'],
+              'run_url': f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}",
+          }
+          Path('benchmark-pr-comment/result.json').write_text(json.dumps(payload, indent=2) + '\n')
+          PY
+      - name: archive PR benchmark comment
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: benchmark-pr-comment
+          path: benchmark-pr-comment
+          if-no-files-found: error
       - name: archive benchmark results
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

--- a/.github/workflows/benchmark_pr_comment.yml
+++ b/.github/workflows/benchmark_pr_comment.yml
@@ -1,0 +1,100 @@
+name: benchmark PR comment
+
+"on":
+  workflow_run:
+    workflows:
+      - benchmark
+    types:
+      - completed
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0]
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: download benchmark PR comment artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifact
+          gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/artifacts" > artifacts.json
+          artifact_id=$(
+            python - <<'PY'
+            import json
+
+            artifacts = json.load(open('artifacts.json'))['artifacts']
+            for artifact in artifacts:
+                if artifact['name'] == 'benchmark-pr-comment':
+                    print(artifact['id'])
+                    break
+            PY
+          )
+          if [ -n "$artifact_id" ]; then
+            gh api \
+              -H "Accept: application/octet-stream" \
+              "repos/${REPOSITORY}/actions/artifacts/${artifact_id}/zip" > artifact.zip
+            python - <<'PY'
+            from zipfile import ZipFile
+
+            ZipFile('artifact.zip').extractall('artifact')
+            PY
+          else
+            cat > artifact/comment.md <<EOF
+            <!-- bidict-benchmark-comment -->
+            ## Benchmark report
+
+            :warning: Benchmark comment artifact not found.
+
+            - Run: [benchmark workflow run](${RUN_URL})
+            - Result: the benchmark workflow completed, but it did not upload the PR comment artifact.
+
+            _This benchmark check is informational and does not block merging._
+            EOF
+          fi
+      - name: create or update sticky benchmark comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" > comments.json
+          comment_id=$(
+            python - <<'PY'
+            import json
+
+            marker = '<!-- bidict-benchmark-comment -->'
+            for comment in json.load(open('comments.json')):
+                if marker in comment['body']:
+                    print(comment['id'])
+                    break
+            PY
+          )
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          body = Path('artifact/comment.md').read_text()
+          Path('comment-payload.json').write_text(json.dumps({'body': body}))
+          PY
+          if [ -n "$comment_id" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${REPOSITORY}/issues/comments/${comment_id}" \
+              --input comment-payload.json
+          else
+            gh api \
+              --method POST \
+              "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --input comment-payload.json
+          fi


### PR DESCRIPTION
## Summary
- have the benchmark workflow publish a PR comment artifact for pull request runs
- add a workflow_run helper that turns that artifact into a sticky PR comment
- keep benchmark comments informational and separate from the code-running workflow permissions

## Testing
- nix develop .#lint --command prek run --all-files --show-diff-on-failure --verbose