### PR TITLE
Remove benchmark comment heredocs

### DIFF
--- a/.github/workflows/benchmark_pr_comment.yml
+++ b/.github/workflows/benchmark_pr_comment.yml
@@ -35,30 +35,9 @@ jobs:
             gh api \
               -H "Accept: application/octet-stream" \
               "repos/${REPOSITORY}/actions/artifacts/${artifact_id}/zip" > artifact.zip
-            python - <<'PY'
-            from zipfile import ZipFile
-
-            ZipFile('artifact.zip').extractall('artifact')
-            PY
+            python -c "from zipfile import ZipFile; ZipFile('artifact.zip').extractall('artifact')"
           else
-            cat > artifact/comment.md <<EOF
-            <!-- bidict-benchmark-comment -->
-            ## Benchmark report
-
-            :warning: Benchmark comment artifact not found.
-
-            - Run: [benchmark workflow run](${RUN_URL})
-            - Result: the benchmark workflow completed, but it did not upload the PR comment artifact.
-
-            _This benchmark check is informational and does not block merging._
-            EOF
-            python - <<'PY'
-            import json
-            import os
-            from pathlib import Path
-
-            Path('artifact/result.json').write_text(json.dumps({'pr_number': os.environ['FALLBACK_PR_NUMBER']}) + '\n')
-            PY
+            python -c "import json, os; from pathlib import Path; Path('artifact/comment.md').write_text('<!-- bidict-benchmark-comment -->\\n## Benchmark report\\n\\n:warning: Benchmark comment artifact not found.\\n\\n- Run: [benchmark workflow run]({})\\n- Result: the benchmark workflow completed, but it did not upload the PR comment artifact.\\n\\n_This benchmark check is informational and does not block merging._\\n'.format(os.environ['RUN_URL'])); Path('artifact/result.json').write_text(json.dumps({'pr_number': os.environ['FALLBACK_PR_NUMBER']}) + '\\n')"
           fi
       - name: create or update sticky benchmark comment
         env:
@@ -75,13 +54,7 @@ jobs:
           comment_id=$(
             python -c "import json; marker = '<!-- bidict-benchmark-comment -->'; comments = json.load(open('comments.json')); print(next((str(comment['id']) for comment in comments if marker in comment['body']), ''))"
           )
-          python - <<'PY'
-          import json
-          from pathlib import Path
-
-          body = Path('artifact/comment.md').read_text()
-          Path('comment-payload.json').write_text(json.dumps({'body': body}))
-          PY
+          python -c "import json; from pathlib import Path; body = Path('artifact/comment.md').read_text(); Path('comment-payload.json').write_text(json.dumps({'body': body}))"
           if [ -n "$comment_id" ]; then
             gh api \
               --method PATCH \


### PR DESCRIPTION
## Summary
- remove the remaining heredocs from the benchmark PR comment helper
- keep the artifact download and sticky comment logic intact using plain python one-liners

## Testing
- nix develop .#lint --command prek run --all-files --show-diff-on-failure --verbose