### PR TITLE
Fix benchmark comment download headers

### DIFF
--- a/.github/workflows/benchmark_pr_comment.yml
+++ b/.github/workflows/benchmark_pr_comment.yml
@@ -34,7 +34,6 @@ jobs:
           if [ -n "$artifact_url" ]; then
             curl -LfsS \
               -H "Authorization: Bearer ${GH_TOKEN}" \
-              -H "Accept: application/octet-stream" \
               "$artifact_url" > artifact.zip
             python -c "from zipfile import ZipFile; ZipFile('artifact.zip').extractall('artifact')"
           else


### PR DESCRIPTION
## Summary
- remove the remaining problematic Accept header from benchmark comment artifact downloads
- keep the curl-based artifact download path intact

## Testing
- nix develop .#lint --command prek run --all-files --show-diff-on-failure --verbose