### PR TITLE
Fix TypeError when comparing OrderedBidict keys() with items() or vice versa

### DIFF
--- a/bidict/_orderedbidict.py
+++ b/bidict/_orderedbidict.py
@@ -116,6 +116,7 @@ class OrderedBidict(OrderedBidictBase[KT, VT], MutableBidict[KT, VT]):
 # provided by the collections.abc superclasses.
 class _OrderedBidictKeysView(BidictKeysView[KT]):
     _mapping: OrderedBidict[KT, t.Any]
+    _viewname: t.ClassVar[str] = 'keys'
 
     def __reversed__(self) -> Iterator[KT]:
         return reversed(self._mapping)
@@ -123,6 +124,7 @@ class _OrderedBidictKeysView(BidictKeysView[KT]):
 
 class _OrderedBidictItemsView(ItemsView[KT, VT]):
     _mapping: OrderedBidict[KT, VT]
+    _viewname: t.ClassVar[str] = 'items'
 
     def __reversed__(self) -> Iterator[tuple[KT, VT]]:
         ob = self._mapping
@@ -166,6 +168,18 @@ def _override_set_methods_to_use_backing_dict(cls: _OView[KT], viewname: str) ->
                 or not isinstance((arg := args[0]), self.__class__)
                 or not isinstance(arg._mapping._fwdm, dict)
             ):
+                # If arg is another ordered bidict view backed by a dict, extract its backing dict view.
+                # This avoids a TypeError when e.g. ob1.keys() < ob2.items(): C-level dict_keys only
+                # compares without error against dict_keys/dict_items, not against custom Set subclasses,
+                # so dict_keys.__lt__(_OrderedBidictItemsView) returns NotImplemented. By passing the
+                # arg's backing dict_items instead, the C-level comparison succeeds correctly.
+                if (
+                    len(args) == 1
+                    and isinstance(arg, (_OrderedBidictKeysView, _OrderedBidictItemsView))
+                    and isinstance(arg._mapping._fwdm, dict)
+                ):
+                    arg_dict_view = getattr(arg._mapping._fwdm, arg._viewname)()
+                    return fwdm_dict_view_method(arg_dict_view)
                 return fwdm_dict_view_method(*args)
             # self and arg are both _OrderedBidictKeysViews or _OrderedBidictItemsViews whose bidicts are backed by
             # a dict. Use arg's backing dict's corresponding view instead of arg. Otherwise, e.g. `ob1.keys()

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -537,6 +537,25 @@ def test_orderedbidict_weakattr_class_access() -> None:
     assert isinstance(descriptor, WeakAttr)
 
 
+def test_orderedbidict_cross_view_set_comparisons() -> None:
+    """Comparing an OrderedBidict keys view with an items view (or vice versa) should behave
+    like comparing the equivalent plain dict views — returning False rather than raising TypeError.
+
+    Regression test: the set-operation proxy methods in _OrderedBidictKeysView and
+    _OrderedBidictItemsView previously passed the opposing custom view type directly to the
+    C-level dict_keys/dict_items methods, which returned NotImplemented (they only recognise
+    dict_keys and dict_items). With both sides returning NotImplemented, Python raised TypeError.
+    The fix extracts the backing dict view from a cross-type _OView arg before forwarding.
+    """
+    ob1 = OrderedBidict({'a': 1, 'b': 2})
+    ob2 = OrderedBidict({'a': 1})
+    d1 = {'a': 1, 'b': 2}
+    d2 = {'a': 1}
+    for op in ('__lt__', '__le__', '__gt__', '__ge__', '__eq__', '__ne__'):
+        assert getattr(ob1.keys(), op)(ob2.items()) == getattr(d1.keys(), op)(d2.items()), op
+        assert getattr(ob1.items(), op)(ob2.keys()) == getattr(d1.items(), op)(d2.keys()), op
+
+
 def test_abc_slots() -> None:
     """Bidict ABCs should define __slots__.
 


### PR DESCRIPTION
## What

Comparing an `OrderedBidict` keys view with an items view (or vice versa) via set comparison operators (`<`, `<=`, `>`, `>=`, `==`, `!=`) raised `TypeError` instead of returning `False` as the equivalent plain-`dict` comparison does.

```python
>>> from bidict import OrderedBidict
>>> ob1 = OrderedBidict({'a': 1, 'b': 2})
>>> ob2 = OrderedBidict({'a': 1})
>>> ob1.keys() < ob2.items()          # before: TypeError; after: False
>>> ob1.items() < ob2.keys()          # before: TypeError; after: False
>>> {'a': 1, 'b': 2}.keys() < {'a': 1}.items()  # plain dict: False (reference)
```

## Why

The set-operation proxy methods installed by `_override_set_methods_to_use_backing_dict()` forward non-matching-class args directly to the backing C-level `dict_keys`/`dict_items` method. C-level dict views only recognise each other — not arbitrary custom `Set` subclasses — so `dict_keys.__lt__(_OrderedBidictItemsView)` returns `NotImplemented`. With both sides of the comparison returning `NotImplemented`, Python raises `TypeError`.

## Fix

Added a `_viewname` class attribute (`'keys'` / `'items'`) to `_OrderedBidictKeysView` and `_OrderedBidictItemsView`. When the incoming arg is an `_OrderedBidictKeysView` or `_OrderedBidictItemsView` backed by a plain `dict`, the proxy now extracts the arg's backing `dict_keys`/`dict_items` view (using `_viewname`) and passes that to the C-level method instead. This restores the correct dict-like behaviour.

The fix is restricted to the cross-type sub-case; the existing same-type optimisation path (both sides are the same `_OView` class) is unchanged.

## Test

Added `test_orderedbidict_cross_view_set_comparisons` which covers all six comparison operators in both directions, asserting that each result matches the equivalent plain-`dict` comparison. Full suite: 115 passed.

Assisted-by: AI tool under my direction and review.