### PR TITLE
Wrap product() in list() where passed to parametrize

### DIFF
--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -348,7 +348,7 @@ def test_eq_defers_to_other_eq(bi_t: BT[KT, VT]) -> None:
     assert bi_t() == ANY
 
 
-@pytest.mark.parametrize(('bi_t', 'non_mapping'), product(bidict_types, (None, 1, [], SupportsKeysAndGetItem({}))))
+@pytest.mark.parametrize(('bi_t', 'non_mapping'), list(product(bidict_types, (None, 1, [], SupportsKeysAndGetItem({})))))
 def test_eq_and_or_with_non_mapping(bi_t: BT[KT, VT], non_mapping: t.Any) -> None:
     bi = bi_t()
     assert bi != non_mapping
@@ -399,7 +399,7 @@ def test_frozenbidicts_hashable(items121: Items121) -> None:
 
 # These test cases ensure coverage of all branches in [Ordered]BidictBase._undo_write.
 # (Hypothesis doesn't always generate examples that cover all the branches otherwise.)
-@pytest.mark.parametrize(('bi_t', 'on_dup'), product(mutable_bidict_types, on_dups))
+@pytest.mark.parametrize(('bi_t', 'on_dup'), list(product(mutable_bidict_types, on_dups)))
 def test_putall_matches_bulk_put(bi_t: type[MutableBidict[int, int]], on_dup: OnDup) -> None:
     bi = bi_t({0: 0, 1: 1})
     for k1, v1, k2, v2 in product(range(4), repeat=4):


### PR DESCRIPTION
## What

Two tests pass an `itertools.product` object directly to
`@pytest.mark.parametrize`:

- `tests/test_bidict.py::test_eq_and_or_with_non_mapping`
- `tests/test_bidict.py::test_putall_matches_bulk_put`

`product(...)` returns a **one-shot iterator, not a `Collection`**. This
change wraps both in `list()` so the argvalues are a concrete
`Collection`.

## Why

Starting with pytest 9.1, passing a non-`Collection` iterable to
`parametrize` raises `PytestRemovedIn10Warning`, and **pytest 10 removes
support entirely** — at which point collecting `tests/test_bidict.py`
will fail. See the pytest deprecation note:
https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators

Today (pytest 8.x/9.x) the suite still collects, but the run already
emits the warning:

```
PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: tests/test_bidict.py::test_eq_and_or_with_non_mapping, argvalues type: product
  Test: tests/test_bidict.py::test_putall_matches_bulk_put, argvalues type: product
```

## Reproduce (deterministic)

Promote the warning to an error exactly as pytest 10 will:

```console
$ python -m pytest tests/ -W "error::pytest.PytestRemovedIn10Warning"
E   pytest.PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
E   Test: tests/test_bidict.py::test_eq_and_or_with_non_mapping, argvalues type: product
ERROR tests/test_bidict.py - pytest.PytestRemovedIn10Warning: ...
!!!!! Interrupted: 1 error during collection !!!!!
1 error in 0.09s
```

## Before / after

| | before (`product(...)`) | after (`list(product(...))`) |
|---|---|---|
| `pytest -W error::pytest.PytestRemovedIn10Warning` | **ERROR at collection** | **114 passed** |
| default `pytest` run | 2 `PytestRemovedIn10Warning` | 0 warnings |

## Notes

- Behavior of the parametrization is unchanged today; this only
  materializes the argvalues into a concrete `Collection`.
- Mirrors the existing `list(powerset(product(ks, vs)))` idiom already
  used in this module.
- No `CHANGELOG.rst` entry: this is a test-tooling-only forward-compat
  fix with no user-facing change, consistent with recent bug-fix PRs
  (#376, #377) which touched only source + tests.
- Full suite green with the project's own config: `114 passed`.
  `ruff check` clean on the changed file.
