### PR TITLE
Fix _dedup no-op detection for keys/values with non-reflexive or asymmetric equality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,13 @@ please consider sponsoring bidict on GitHub.`
   Use e.g. :func:`importlib.metadata.metadata("bidict")["Version"]
   <importlib.metadata.metadata>` instead.
 
+- Fix a bug where setting an already-contained (key, value) pair
+  spuriously raised :class:`~bidict.KeyAndValueDuplicationError`
+  or ``AssertionError`` (rather than being a no-op, as documented)
+  when the key or value has non-reflexive equality (e.g. *nan*)
+  or asymmetric equality.
+  :issue:`377`
+
 
 0.23.1 (2024-02-18)
 -------------------

--- a/bidict/_base.py
+++ b/bidict/_base.py
@@ -339,8 +339,8 @@ class BidictBase(BidirectionalMapping[KT, VT]):
         oldkey: OKT[KT] = invm.get(val, MISSING)
         isdupkey, isdupval = oldval is not MISSING, oldkey is not MISSING
         if isdupkey and isdupval:
-            if key == oldkey:
-                assert val == oldval
+            if key is oldkey or key == oldkey:
+                assert val is oldval or val == oldval
                 # (key, val) duplicates an existing item -> no-op.
                 return None
             # key and val each duplicate a different existing item.

--- a/bidict/_base.py
+++ b/bidict/_base.py
@@ -337,12 +337,11 @@ class BidictBase(BidirectionalMapping[KT, VT]):
         fwdm, invm = self._fwdm, self._invm
         oldval: OVT[VT] = fwdm.get(key, MISSING)
         oldkey: OKT[KT] = invm.get(val, MISSING)
-        isdupkey, isdupval = oldval is not MISSING, oldkey is not MISSING
+        isdupkey = oldval is not MISSING
+        isdupval = oldkey is not MISSING
         if isdupkey and isdupval:
-            if key is oldkey or key == oldkey:
-                assert val is oldval or val == oldval
-                # (key, val) duplicates an existing item -> no-op.
-                return None
+            if fwdm[oldkey] is oldval:  # type: ignore[index]  # mypy can't narrow oldkey to KT here (ty can)
+                return None  # (key, val) duplicates an existing item -> no-op
             # key and val each duplicate a different existing item.
             if on_dup.val is RAISE:
                 raise KeyAndValueDuplicationError(key, val)
@@ -364,7 +363,7 @@ class BidictBase(BidirectionalMapping[KT, VT]):
                 return None
             assert on_dup.val is DROP_OLD
             # Fall through to the return statement on the last line.
-        # else neither isdupkey nor isdupval.
+        # else no key or value duplication.
         return oldkey, oldval
 
     def _write(self, newkey: KT, newval: VT, oldkey: OKT[KT], oldval: OVT[VT], unwrites: Unwrites | None) -> None:

--- a/docs/addendum.rst
+++ b/docs/addendum.rst
@@ -210,6 +210,20 @@ for dealing with *nan* as a key,
 so bidict's behavior will match :class:`dict`'s
 on whatever runtime you're using.
 
+Note that even though *nan* is not equal to itself,
+re-inserting an already-contained item using the same *nan* object
+is still construed as a no-op
+(see :ref:`basic-usage:Key and Value Duplication`):
+
+.. doctest::
+
+   >>> b = bidict()
+   >>> nan = float('nan')
+   >>> b[nan] = 'nan'
+   >>> b[nan] = 'nan'  # no-op, does not raise
+   >>> b
+   bidict({nan: 'nan'})
+
 See e.g. `these docs
 <https://doc.pypy.org/en/latest/cpython_differences.html>`__
 for more info (search the page for "nan").

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -563,6 +563,29 @@ def test_static_types() -> None:
     assert_type(fb.inv, frozenbidict[int, str])
 
 
+@pytest.mark.parametrize('bi_t', mutable_bidict_types)
+def test_setitem_existing_is_noop_with_nonreflexive_eq(bi_t: MBT[t.Any, t.Any]) -> None:
+    """Setting an existing (key, val) pair should be a no-op even when key == key is False.
+
+    Float NaN has non-reflexive equality (nan != nan), so it exercises
+    the identity-based fallback in _dedup that avoids a spurious
+    KeyAndValueDuplicationError or AssertionError.
+    """
+    nan = float('nan')
+    # NaN as key: b[nan] = 'a' again must not raise
+    b = bi_t()
+    b[nan] = 'a'
+    b[nan] = 'a'
+    assert len(b) == 1
+    assert b[nan] == 'a'
+    # NaN as value: b['x'] = nan again must not raise
+    b2 = bi_t()
+    b2['x'] = nan
+    b2['x'] = nan
+    assert len(b2) == 1
+    assert b2['x'] is nan
+
+
 def assert_calls_match(call1: Callable[..., t.Any], call2: Callable[..., t.Any]) -> None:
     results: dict[t.Any, t.Any] = {call1: None, call2: None}
     for call in results:

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -568,7 +568,7 @@ def test_setitem_existing_is_noop_with_nonreflexive_eq(bi_t: MBT[t.Any, t.Any]) 
     """Setting an existing (key, val) pair should be a no-op even when key == key is False.
 
     Float NaN has non-reflexive equality (nan != nan), so it exercises
-    the identity-based fallback in _dedup that avoids a spurious
+    the identity-based same-item check in _dedup that avoids a spurious
     KeyAndValueDuplicationError or AssertionError.
     """
     nan = float('nan')
@@ -584,6 +584,60 @@ def test_setitem_existing_is_noop_with_nonreflexive_eq(bi_t: MBT[t.Any, t.Any]) 
     b2['x'] = nan
     assert len(b2) == 1
     assert b2['x'] is nan
+    # A key or value that duplicates an existing item's key and an existing
+    # *different* item's value must still raise, even when it's the same NaN object:
+    b3 = bi_t()
+    b3[nan] = 'a'
+    b3['x'] = nan
+    with pytest.raises(KeyAndValueDuplicationError):
+        b3[nan] = nan
+
+
+class _AsymStored:
+    """Pathological type equal to _AsymLookup instances, but only when on the left-hand side."""
+
+    def __hash__(self) -> int:
+        return 1
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _AsymLookup)
+
+
+class _AsymLookup:
+    """Pathological type that is never equal to anything, even when an _AsymStored equals it."""
+
+    def __hash__(self) -> int:
+        return 1
+
+    def __eq__(self, other: object) -> bool:
+        return False
+
+
+@pytest.mark.parametrize('bi_t', mutable_bidict_types)
+def test_setitem_existing_is_noop_with_asymmetric_eq(bi_t: MBT[t.Any, t.Any]) -> None:
+    """Setting an existing (key, val) pair should be a no-op even when __eq__ is asymmetric.
+
+    dict lookup compares stored == lookup (in CPython), so a lookup key that a stored key
+    compares equal to hits the stored key's item even when lookup == stored is False.
+    _dedup must agree with the dict lookups rather than re-checking equality itself
+    (with operands in the opposite order) and wrongly concluding the items differ.
+    """
+    stored, lookup = _AsymStored(), _AsymLookup()
+    probe: dict[t.Any, str] = {stored: 'hit'}
+    if probe.get(lookup) != 'hit':
+        pytest.skip('dict lookup on this runtime does not compare stored == lookup')
+    # Asymmetric key: dict considers *lookup* the same key as *stored* -> no-op
+    b1 = bi_t()
+    b1[stored] = 'v'
+    b1[lookup] = 'v'
+    assert len(b1) == 1
+    assert next(iter(b1)) is stored
+    # Asymmetric value -> no-op
+    b2 = bi_t()
+    b2['x'] = stored
+    b2['x'] = lookup
+    assert len(b2) == 1
+    assert b2['x'] is stored
 
 
 def assert_calls_match(call1: Callable[..., t.Any], call2: Callable[..., t.Any]) -> None:


### PR DESCRIPTION
## What

Setting an already-contained (key, value) pair is documented to be a no-op, but spuriously raised `KeyAndValueDuplicationError` or `AssertionError` when the key or value has pathological equality semantics:

- **Non-reflexive equality** (e.g. `float('nan')`, where `nan != nan`) — reported and fixed in #377 (thanks @gaoflow!), whose commit is included here unchanged.
- **Asymmetric equality** (where `stored == lookup` but `lookup != stored`) — a second commit on top extends the fix to cover this case as well, by making `_dedup`'s same-item check fully identity-based (`fwdm[oldkey] is oldval`) rather than re-checking equality at all, delegating all equality semantics to the backing dict lookups themselves.

The follow-up commit also removes the `assert` in that branch (making behavior consistent between `python -O` and normal runs), adds tests for the asymmetric case and for the mixed case where the same nan object duplicates two *different* items (which must still raise), adds a CHANGELOG entry, and adds a doctest to the addendum's "*nan* as a Key" section demonstrating the now-correct no-op behavior.

## Note on merging

This PR includes the commit from #377, so merging it (with a merge commit — not squash/rebase) will automatically mark #377 as merged as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)