### PR TITLE
Add CLAUDE.md and document testing + SemBr conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Orientation
+
+`bidict` is a mature, dependency-free bidirectional mapping library
+for Python (>=3.11, CPython + PyPy).
+The public API is small;
+the value is in the carefully-factored, fully type-hinted implementation.
+Optimize for correctness, API stability, and long-term maintainability
+over cleverness.
+There are **zero runtime dependencies** (standard library only) —
+do not add any.
+
+## Canonical docs (imported so their content is in-session)
+
+These human-facing docs are the single source of truth.
+When the underlying facts change,
+update *them* rather than duplicating anything here:
+
+- Contributor workflow —
+  dev environment, running tests and checks, single-test invocation,
+  the property-based (Hypothesis) testing approach,
+  code style and lint, commit conventions,
+  the Semantic Line Breaks prose convention,
+  and the fact that doctests in modules and `docs/*.rst` run as tests:
+  @CONTRIBUTING.rst
+- Architecture, code structure,
+  and the guided "code review nav" reading order through the source:
+  @docs/learning-from-bidict.rst
+- Extending bidict —
+  custom subclasses, `on_dup` policies, dynamic inverse-class generation:
+  @docs/extending.rst
+
+## Working in this codebase (Claude-specific notes)
+
+- Prose here and in the docs follows
+  [Semantic Line Breaks](https://sembr.org) (see CONTRIBUTING.rst):
+  one sentence per line, breaking at clause boundaries —
+  don't reflow paragraphs to fill columns.
+- Follow the "Code review nav" banner comments
+  at the top and bottom of each key file
+  (start in `bidict/__init__.py`);
+  they define the author's intended reading order.
+  `_base.py`'s `BidictBase` is the heart of the library.
+- `_base.py` holds the subtle machinery,
+  each piece explained in inline comments —
+  **read those comments before editing** the relevant code.
+  The landmarks to be careful around:
+  - a bidict and its `.inverse` **share** the same two backing dicts
+    (`_fwdm`/`_invm`, swapped),
+    so mutations through either are visible in both;
+  - the `inverse` property's strong-ref/weakref pair,
+    which exposes the inverse without creating a reference cycle;
+  - `_ensure_inv_cls`/`_make_inv_cls`,
+    which synthesize a distinct inverse class
+    when the forward and inverse backing types differ
+    (intentionally corecursive with `__init_subclass__`);
+  - the `_dedup` → `_write` mutation path,
+    which records "unwrites"
+    so a failing bulk `_update` rolls back atomically.
+- Every source file carries the MPL-2.0 header —
+  include it on new files.
+  Public API changes must be reflected in `CHANGELOG.rst`
+  and the relevant `docs/*.rst`.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -96,6 +96,64 @@ Making Changes
     the patch, why it's a problem, and how the patch fixes the problem.
 
 
+Running Tests and Checks
+------------------------
+
+The commands below assume you've run ``./init_dev_env`` and are using the
+resulting virtualenv, either by prefixing each command with ``uv run`` or
+after activating ``.venv``.
+
+- Run the test suite on your current Python: ``pytest``
+
+- Run a single test:
+  ``pytest tests/test_bidict.py::test_frozenbidicts_hashable``
+
+- Run the tests for every supported Python version: ``tox``
+  (see ``envlist`` in ``tox.ini`` for the list).
+
+- Type-check the code: ``mypy bidict tests`` (mypy runs in strict mode).
+
+- Run all the lint, format, and style hooks: ``prek run --all-files``
+  (equivalently, ``tox -e lint``).
+
+- Build the docs: ``tox -e docs``.
+
+Note that the test suite (configured under ``[tool.pytest]`` in
+``pyproject.toml``) executes the doctests in every module's docstrings
+**as well as** the code blocks in ``docs/*.rst`` files. In other words,
+example code in docstrings and docs is run as part of the tests, so be sure
+to keep it correct and up to date.
+
+
+Most of bidict's tests are property-based,
+written using `Hypothesis <https://hypothesis.works>`__.
+The bulk of the suite lives in ``tests/test_bidict.py``,
+centered on ``BidictStateMachine``
+(a `stateful <https://hypothesis.readthedocs.io/en/latest/stateful.html>`__
+``RuleBasedStateMachine``)
+that checks bidict's invariants against a simpler reference model,
+with user-defined bidict subclass fixtures in ``tests/bidict_test_fixtures.py``.
+When adding behavior,
+prefer extending these properties and invariants
+(and adding doctests where they help document usage)
+over adding one-off, example-based tests.
+
+
+Documentation and Prose Style
+-----------------------------
+
+Prose in bidict's documentation, docstrings, comments, and commit messages
+follows `Semantic Line Breaks <https://sembr.org>`__ (SemBr):
+start a new line after each sentence,
+and optionally at other natural boundaries between clauses or phrases,
+rather than hard-wrapping at a fixed column width
+or placing an entire paragraph on a single line.
+Because both Markdown and reStructuredText collapse
+a single line break within a paragraph into a space,
+this keeps the rendered output unchanged
+while making diffs smaller and easier to review.
+
+
 Submitting Changes
 ------------------
 


### PR DESCRIPTION
## What

Adds a `CLAUDE.md` to give Claude Code sessions pre-loaded context for this repo, and single-sources into `CONTRIBUTING.rst` the content that is just as relevant to human contributors.

## Approach

To avoid duplicating human-relevant content (and the drift that causes), `CLAUDE.md` is kept thin. It uses Claude Code's `@import` mechanism to pull the canonical human-facing docs into each session's context rather than restating them:

- `@CONTRIBUTING.rst` — dev environment, running tests/checks, testing approach, code style, commit and prose conventions
- `@docs/learning-from-bidict.rst` — architecture and the "code review nav" reading order
- `@docs/extending.rst` — subclassing, `on_dup`, dynamic inverse-class generation

Beyond the imports, `CLAUDE.md` adds only Claude-specific orientation plus pointers into the self-documenting source (`_base.py`'s subtle machinery is flagged, with a note to read the existing inline comments rather than re-explaining them here).

## CONTRIBUTING.rst additions

Two facts that would otherwise live only in `CLAUDE.md`, but are equally useful to humans, are single-sourced here:

- **Running Tests and Checks** — command quick-reference (including single-test invocation and the note that doctests in modules and `docs/*.rst` run as tests) plus a description of the property-based (Hypothesis) testing approach.
- **Documentation and Prose Style** — makes explicit the project's existing conformance to [Semantic Line Breaks](https://sembr.org). `CLAUDE.md`'s own prose conforms to SemBr as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)