### PR TITLE
Fix OrderedBidict cross-view set operations (builds on #376)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,12 @@ please consider sponsoring bidict on GitHub.`
   or asymmetric equality.
   :issue:`377`
 
+- Fix a bug where set operations between an :class:`~bidict.OrderedBidict`'s
+  keys view and its items view (or vice versa) raised :class:`TypeError`
+  (or, for ``==``, returned the wrong result)
+  rather than behaving like the equivalent plain :class:`dict` views.
+  :issue:`376`
+
 
 0.23.1 (2024-02-18)
 -------------------

--- a/bidict/_orderedbidict.py
+++ b/bidict/_orderedbidict.py
@@ -155,40 +155,29 @@ _setmethodnames: Iterable[str] = (
 )
 
 
-def _override_set_methods_to_use_backing_dict(cls: _OView[KT], viewname: str) -> None:
+def _override_set_methods_to_use_backing_dict(cls: _OView[KT]) -> None:
     def make_proxy_method(methodname: str) -> t.Any:
         def method(self: _OrderedBidictKeysView[KT] | _OrderedBidictItemsView[KT, t.Any], *args: t.Any) -> t.Any:
             fwdm = self._mapping._fwdm
             if not isinstance(fwdm, dict):  # dict view speedup not available, fall back to Set's implementation.
                 return getattr(Set, methodname)(self, *args)
-            fwdm_dict_view = getattr(fwdm, viewname)()
+            fwdm_dict_view = getattr(fwdm, self._viewname)()
             fwdm_dict_view_method = getattr(fwdm_dict_view, methodname)
+            # When the (single) arg is another _OrderedBidict{Keys,Items}View backed by a dict, forward its
+            # backing dict_keys/dict_items to the C-level method rather than the arg itself. C-level dict views
+            # only interoperate with other C-level dict views, not with arbitrary Set subclasses, so e.g.
+            # `dict_keys(ob1).__lt__(ob2.keys())` returns NotImplemented. With both sides returning
+            # NotImplemented, Python either raises TypeError (for `<`, `<=`, `>`, `>=`) or falls back to the
+            # wrong answer (e.g. identity-based `==`). Note arg's view may differ from self's (keys vs items),
+            # so use arg._viewname; this also subsumes the same-type case, where it equals self._viewname.
             if (
-                len(args) != 1
-                or not isinstance((arg := args[0]), self.__class__)
-                or not isinstance(arg._mapping._fwdm, dict)
+                len(args) == 1
+                and isinstance((arg := args[0]), (_OrderedBidictKeysView, _OrderedBidictItemsView))
+                and isinstance(arg._mapping._fwdm, dict)
             ):
-                # If arg is another ordered bidict view backed by a dict, extract its backing dict view.
-                # This avoids a TypeError when e.g. ob1.keys() < ob2.items(): C-level dict_keys only
-                # compares without error against dict_keys/dict_items, not against custom Set subclasses,
-                # so dict_keys.__lt__(_OrderedBidictItemsView) returns NotImplemented. By passing the
-                # arg's backing dict_items instead, the C-level comparison succeeds correctly.
-                if (
-                    len(args) == 1
-                    and isinstance(arg, (_OrderedBidictKeysView, _OrderedBidictItemsView))
-                    and isinstance(arg._mapping._fwdm, dict)
-                ):
-                    arg_dict_view = getattr(arg._mapping._fwdm, arg._viewname)()
-                    return fwdm_dict_view_method(arg_dict_view)
-                return fwdm_dict_view_method(*args)
-            # self and arg are both _OrderedBidictKeysViews or _OrderedBidictItemsViews whose bidicts are backed by
-            # a dict. Use arg's backing dict's corresponding view instead of arg. Otherwise, e.g. `ob1.keys()
-            # < ob2.keys()` would give "TypeError: '<' not supported between instances of '_OrderedBidictKeysView' and
-            # '_OrderedBidictKeysView'", because both `dict_keys(ob1).__lt__(ob2.keys()) is NotImplemented` and
-            # `dict_keys(ob2).__gt__(ob1.keys()) is NotImplemented`.
-            arg_dict = arg._mapping._fwdm
-            arg_dict_view = getattr(arg_dict, viewname)()
-            return fwdm_dict_view_method(arg_dict_view)
+                arg_dict_view = getattr(arg._mapping._fwdm, arg._viewname)()
+                return fwdm_dict_view_method(arg_dict_view)
+            return fwdm_dict_view_method(*args)
 
         method.__name__ = methodname
         method.__qualname__ = f'{cls.__qualname__}.{methodname}'
@@ -198,8 +187,8 @@ def _override_set_methods_to_use_backing_dict(cls: _OView[KT], viewname: str) ->
         setattr(cls, name, make_proxy_method(name))
 
 
-_override_set_methods_to_use_backing_dict(_OrderedBidictKeysView, 'keys')
-_override_set_methods_to_use_backing_dict(_OrderedBidictItemsView, 'items')
+_override_set_methods_to_use_backing_dict(_OrderedBidictKeysView)
+_override_set_methods_to_use_backing_dict(_OrderedBidictItemsView)
 
 
 #                             * Code review nav *

--- a/bidict/_orderedbidict.py
+++ b/bidict/_orderedbidict.py
@@ -116,6 +116,7 @@ class OrderedBidict(OrderedBidictBase[KT, VT], MutableBidict[KT, VT]):
 # provided by the collections.abc superclasses.
 class _OrderedBidictKeysView(BidictKeysView[KT]):
     _mapping: OrderedBidict[KT, t.Any]
+    _viewname: t.ClassVar[str] = 'keys'
 
     def __reversed__(self) -> Iterator[KT]:
         return reversed(self._mapping)
@@ -123,6 +124,7 @@ class _OrderedBidictKeysView(BidictKeysView[KT]):
 
 class _OrderedBidictItemsView(ItemsView[KT, VT]):
     _mapping: OrderedBidict[KT, VT]
+    _viewname: t.ClassVar[str] = 'items'
 
     def __reversed__(self) -> Iterator[tuple[KT, VT]]:
         ob = self._mapping
@@ -166,6 +168,18 @@ def _override_set_methods_to_use_backing_dict(cls: _OView[KT], viewname: str) ->
                 or not isinstance((arg := args[0]), self.__class__)
                 or not isinstance(arg._mapping._fwdm, dict)
             ):
+                # If arg is another ordered bidict view backed by a dict, extract its backing dict view.
+                # This avoids a TypeError when e.g. ob1.keys() < ob2.items(): C-level dict_keys only
+                # compares without error against dict_keys/dict_items, not against custom Set subclasses,
+                # so dict_keys.__lt__(_OrderedBidictItemsView) returns NotImplemented. By passing the
+                # arg's backing dict_items instead, the C-level comparison succeeds correctly.
+                if (
+                    len(args) == 1
+                    and isinstance(arg, (_OrderedBidictKeysView, _OrderedBidictItemsView))
+                    and isinstance(arg._mapping._fwdm, dict)
+                ):
+                    arg_dict_view = getattr(arg._mapping._fwdm, arg._viewname)()
+                    return fwdm_dict_view_method(arg_dict_view)
                 return fwdm_dict_view_method(*args)
             # self and arg are both _OrderedBidictKeysViews or _OrderedBidictItemsViews whose bidicts are backed by
             # a dict. Use arg's backing dict's corresponding view instead of arg. Otherwise, e.g. `ob1.keys()

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -537,6 +537,25 @@ def test_orderedbidict_weakattr_class_access() -> None:
     assert isinstance(descriptor, WeakAttr)
 
 
+def test_orderedbidict_cross_view_set_comparisons() -> None:
+    """Comparing an OrderedBidict keys view with an items view (or vice versa) should behave
+    like comparing the equivalent plain dict views — returning False rather than raising TypeError.
+
+    Regression test: the set-operation proxy methods in _OrderedBidictKeysView and
+    _OrderedBidictItemsView previously passed the opposing custom view type directly to the
+    C-level dict_keys/dict_items methods, which returned NotImplemented (they only recognise
+    dict_keys and dict_items). With both sides returning NotImplemented, Python raised TypeError.
+    The fix extracts the backing dict view from a cross-type _OView arg before forwarding.
+    """
+    ob1 = OrderedBidict({'a': 1, 'b': 2})
+    ob2 = OrderedBidict({'a': 1})
+    d1 = {'a': 1, 'b': 2}
+    d2 = {'a': 1}
+    for op in ('__lt__', '__le__', '__gt__', '__ge__', '__eq__', '__ne__'):
+        assert getattr(ob1.keys(), op)(ob2.items()) == getattr(d1.keys(), op)(d2.items()), op
+        assert getattr(ob1.items(), op)(ob2.keys()) == getattr(d1.items(), op)(d2.keys()), op
+
+
 def test_abc_slots() -> None:
     """Bidict ABCs should define __slots__.
 

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -537,21 +537,30 @@ def test_orderedbidict_weakattr_class_access() -> None:
     assert isinstance(descriptor, WeakAttr)
 
 
-def test_orderedbidict_cross_view_set_comparisons() -> None:
-    """Comparing an OrderedBidict keys view with an items view (or vice versa) should behave
-    like comparing the equivalent plain dict views — returning False rather than raising TypeError.
+def test_orderedbidict_cross_view_set_operations() -> None:
+    """Set operations between an OrderedBidict keys view and an items view (or vice versa) should
+    behave like the equivalent plain dict views rather than raising TypeError or giving a wrong result.
 
     Regression test: the set-operation proxy methods in _OrderedBidictKeysView and
     _OrderedBidictItemsView previously passed the opposing custom view type directly to the
     C-level dict_keys/dict_items methods, which returned NotImplemented (they only recognise
-    dict_keys and dict_items). With both sides returning NotImplemented, Python raised TypeError.
+    dict_keys and dict_items). With both sides returning NotImplemented, Python raised TypeError
+    (for the ordering comparisons) or fell back to the wrong answer (e.g. identity-based __eq__).
     The fix extracts the backing dict view from a cross-type _OView arg before forwarding.
     """
     ob1 = OrderedBidict({'a': 1, 'b': 2})
     ob2 = OrderedBidict({'a': 1})
     d1 = {'a': 1, 'b': 2}
     d2 = {'a': 1}
-    for op in ('__lt__', '__le__', '__gt__', '__ge__', '__eq__', '__ne__'):
+    # The comparison operators return bools; the set-algebra operators return sets/bools. In every
+    # case the OrderedBidict view result must match the equivalent plain dict view result exactly.
+    # fmt: off
+    ops = (
+        '__lt__', '__le__', '__gt__', '__ge__', '__eq__', '__ne__',  # comparisons
+        '__sub__', '__or__', '__xor__', '__and__', 'isdisjoint',  # set algebra
+    )
+    # fmt: on
+    for op in ops:
         assert getattr(ob1.keys(), op)(ob2.items()) == getattr(d1.keys(), op)(d2.items()), op
         assert getattr(ob1.items(), op)(ob2.keys()) == getattr(d1.items(), op)(d2.keys()), op
 


### PR DESCRIPTION
## What

Fixes `TypeError` (and, for `==`, a wrong result) when performing a set
operation between an `OrderedBidict`'s keys view and its items view (or
vice versa), so they behave like the equivalent plain-`dict` views:

```python
>>> from bidict import OrderedBidict
>>> OrderedBidict({'a': 1, 'b': 2}).keys() < OrderedBidict({'a': 1}).items()
False  # before: TypeError
```

## Relationship to #376

This builds on @gaoflow's fix in #376. The first commit is that fix,
cherry-picked unchanged (authorship preserved). The second commit is a
follow-up that:

- **Simplifies the implementation.** The original fix added a nested
  conditional duplicating the pre-existing same-type branch — both extract
  the arg's backing `dict_keys`/`dict_items` and forward it to the C-level
  method. Since `arg._viewname` already names the arg's own view, it is
  correct for the same-type case too, so the two branches collapse into
  one and the `isinstance(arg, self.__class__)` special-casing goes away.
  Deriving the view name from `self._viewname`/`arg._viewname` also lets
  `_override_set_methods_to_use_backing_dict` drop its now-redundant
  `viewname` parameter (removing the second source of truth for
  `'keys'`/`'items'`).

- **Broadens the regression test.** The bug affects every set operation
  the proxy wraps, not just the comparison operators, so the test now also
  covers `-`, `|`, `^`, `&`, and `isdisjoint`, asserting each matches the
  equivalent plain-`dict` view result.

- **Adds a `CHANGELOG.rst` entry.**

## Verification

- `mypy bidict tests` — clean
- Full suite (incl. module + `docs/*.rst` doctests) — 133 passed
- `prek run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)