### PR TITLE
Cache the Nix store in CI to avoid cold cache.nixos.org fetch stalls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25
+      - name: cache the Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d
       - name: cache .mypy_cache dir
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:


### PR DESCRIPTION
## Problem

Every job in `test.yml` realizes its dev shell with `nix develop .#<shell>`, but there was no GitHub Actions cache of the Nix store — so each run cold-fetches its store paths from `cache.nixos.org`. The CPython shells share already-warm paths and finish in ~1 min, but the `testPyPy311` shell must copy the large `pypy3.11` store path. When that upstream copy stalls (as it intermittently does), the `pypy-3.11` job hangs for many minutes in the "run mypy and pytest" step **before a single test runs**, gating CI for reasons unrelated to the change under test.

This just happened on #384, where the `pypy-3.11` job stalled ~7 min in the Nix fetch and only went green after a re-run.

## Fix

Add [`DeterminateSystems/magic-nix-cache-action`](https://github.com/DeterminateSystems/magic-nix-cache-action) immediately after the Nix install step. It's free, zero-config, and backed by the GitHub Actions cache already available (no account, no secrets). Realized store paths are cached at job end and restored on later runs, so the warm `pypy3.11` path is served from the Actions cache instead of cold-fetched from `cache.nixos.org`.

- Pinned to the `v14` release-commit SHA, matching the repo's existing pinning convention (kept current by the `github-actions-version-updater` job).
- Placed after `install Nix` (it registers a substituter, so it must run before any `nix` command) and before the later `nix develop`.

## Note on rollout

The warm-cache payoff only fully materializes **after** this merges to `main` and a `push`-to-`main` run populates the cache; the first run on this PR is expected to look unchanged (its cache starts empty). Cache writes are also scoped away from fork PRs by GitHub, but caches populated on `main` are readable by subsequent PRs, so the common path still benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)