### PR TITLE
Treat pytest warnings as errors (+ benchmark-plugin and docs cleanups)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ name: tests
 
 env:
   FORCE_COLOR: "1"
-  PYTEST_ADDOPTS: "--benchmark-disable"
 
 jobs:
   test-all:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,22 @@ update *them* rather than duplicating anything here:
 
 ## Working in this codebase (Claude-specific notes)
 
-- Prose here and in the docs follows
-  [Semantic Line Breaks](https://sembr.org) (see CONTRIBUTING.rst):
-  one sentence per line, breaking at clause boundaries —
+- Run dev tooling through the Nix dev shell, not the bare `.venv`:
+  prefix commands with `nix develop --command bash -c '...'`
+  (or work from within a `nix develop` shell).
+  `prek`, `tox`, and the docs build are provided only by the Nix shell,
+  so invoking them outside it fails with "command not found" —
+  even though `pytest` and `mypy` happen to also be in `.venv`,
+  which makes it easy to forget.
+  The committed `.envrc` (`use flake`) does not help here,
+  because direnv has no hook in the non-interactive subshells
+  spawned for these tool calls.
+- SemBr ([Semantic Line Breaks](https://sembr.org), see CONTRIBUTING.rst)
+  applies to prose in Markdown and reStructuredText documents only
+  (this file, `CONTRIBUTING.rst`, `docs/*.rst`):
+  one sentence per line, breaking at clause boundaries,
   don't reflow paragraphs to fill columns.
+  It does *not* apply to code, code comments, docstrings, or commit messages.
 - Follow the "Code review nav" banner comments
   at the top and bottom of each key file
   (start in `bidict/__init__.py`);

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -99,9 +99,17 @@ Making Changes
 Running Tests and Checks
 ------------------------
 
-The commands below assume you've run ``./init_dev_env`` and are using the
-resulting virtualenv, either by prefixing each command with ``uv run`` or
-after activating ``.venv``.
+The commands below assume you have an active development environment,
+set up per the steps above.
+Commands that run against the ``./init_dev_env`` virtualenv (such as ``pytest``)
+can be prefixed with ``uv run``
+or run after activating ``.venv``.
+Note, however, that ``prek`` — used by the lint, format, and style hooks,
+including via ``tox -e lint`` — is provided by the ``nix develop`` shell
+(or your own PATH, if you installed it manually per the setup steps above),
+not by the ``./init_dev_env`` virtualenv,
+so run those from within ``nix develop``
+(or otherwise ensure ``prek`` is on your PATH).
 
 - Run the test suite on your current Python: ``pytest``
 
@@ -142,7 +150,8 @@ over adding one-off, example-based tests.
 Documentation and Prose Style
 -----------------------------
 
-Prose in bidict's documentation, docstrings, comments, and commit messages
+Prose in bidict's Markdown and reStructuredText documents
+(this file, the ``*.rst`` files under ``docs/``, etc.)
 follows `Semantic Line Breaks <https://sembr.org>`__ (SemBr):
 start a new line after each sentence,
 and optionally at other natural boundaries between clauses or phrases,
@@ -152,6 +161,8 @@ Because both Markdown and reStructuredText collapse
 a single line break within a paragraph into a space,
 this keeps the rendered output unchanged
 while making diffs smaller and easier to review.
+This convention applies to these prose documents only,
+not to code, code comments, docstrings, or commit messages.
 
 
 Submitting Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,11 @@ addopts = [
   "--durations=5",
   "--hypothesis-profile=less-examples",
   "--numprocesses=auto",
+  # Benchmarks are run separately (see the benchmark tox env and workflow, which
+  # invoke pytest with `-c /dev/null` to bypass this config), so unload
+  # pytest-benchmark here. Otherwise, being installed, it loads on every run and
+  # warns under xdist (which addopts enables above) that it is auto-disabling itself.
+  "-p", "no:benchmark",
 ]
 doctest_optionflags = ["ELLIPSIS"]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,5 +147,9 @@ addopts = [
   "-p", "no:benchmark",
 ]
 doctest_optionflags = ["ELLIPSIS"]
+# Treat warnings as errors so deprecations etc. fail the suite instead of going
+# unnoticed. (The benchmark plugin is unloaded above so its xdist warning
+# doesn't trip this.)
+filterwarnings = ["error"]
 strict = true
 testpaths = ["bidict", "tests", "docs"]


### PR DESCRIPTION
## What

Three small, independent commits:

1. **Clarify SemBr scope and how to run dev tooling** (`CLAUDE.md`, `CONTRIBUTING.rst`)
   - Narrow the Semantic Line Breaks convention to Markdown/reStructuredText prose documents only, stating explicitly that code, code comments, docstrings, and commit messages are out of scope (the existing example commit message is column-wrapped, not SemBr, so this matches reality).
   - Fix a `.venv`-vs-Nix trap: the "Running Tests and Checks" preamble implied every command (including `prek`) runs against the `./init_dev_env` virtualenv, but `prek` (and `tox -e lint`, which invokes it) is provided by the `nix develop` shell / your PATH, not that virtualenv. Document this, and add a Claude-specific note in `CLAUDE.md`.

2. **Stop loading pytest-benchmark during the normal test suite** (`pyproject.toml`, `.github/workflows/test.yml`)
   - The normal suite runs under xdist (`--numprocesses=auto`), so pytest-benchmark loads on every run and emits a `PytestBenchmarkWarning` that it is auto-disabling itself — even though benchmarks are never collected in the normal run (`microbenchmarks.py` lives outside `testpaths` and is run separately via `pytest -c /dev/null -n0`). CI papered over it with `PYTEST_ADDOPTS="--benchmark-disable"`.
   - Add `-p no:benchmark` to `addopts` to remove the warning at its source, and drop the now-redundant `--benchmark-disable` from the tests workflow. Benchmark runs are unaffected (they bypass this config with `-c /dev/null`).

3. **Treat pytest warnings as errors** (`pyproject.toml`)
   - Add `filterwarnings = ["error"]` so a warning during the test run (e.g. a deprecation like the `PytestRemovedIn10Warning` that #380 addressed) fails the suite immediately instead of scrolling past unnoticed. Safe now that commit 2 removed the spurious benchmark warning.

## Why

`filterwarnings = ["error"]` is the durable guard that would have caught the deprecation #380 fixed. Enabling it surfaced the pytest-benchmark/xdist warning as a hard collection error, which is what commit 2 resolves at its root (rather than layering another `--benchmark-disable`-style workaround). Commit 1 documents the dev-shell requirement that this work surfaced.

## Notes

- Each commit stands alone and the history bisects cleanly: the intermediate state after commit 2 also passes.
- Full suite green under the project's own config (`133 passed`, zero warnings), and `prek` clean, both verified inside `nix develop`.
- No `CHANGELOG.rst` entry: test-tooling and docs only, no user-facing/runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
