### PR TITLE
Disable FlakeHub in magic-nix-cache-action; use GHA cache only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,12 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25
       - name: cache the Nix store
         uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d
+        with:
+          # Use only the GitHub Actions cache; we don't authenticate to FlakeHub, and leaving it
+          # enabled makes the action log a noisy (non-fatal) "Cannot find netrc credentials for
+          # https://api.flakehub.com/" error before falling back to the GHA cache.
+          use-flakehub: false
+          use-gha-cache: true
       - name: cache .mypy_cache dir
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:


### PR DESCRIPTION
## Problem

After #385 added `magic-nix-cache-action`, CI logs an alarming (but **non-fatal**) error in the "cache the Nix store" step:

```
ERROR magic_nix_cache: FlakeHub: cache initialized failed: Unauthenticated: Cannot find netrc credentials for https://api.flakehub.com/
```

Recent versions of the action default `use-flakehub` to "no-preference" and try [FlakeHub Cache](https://docs.determinate.systems/flakehub/cache/) opportunistically. bidict doesn't authenticate to FlakeHub (a paid/authenticated service), so the attempt fails and the action falls back to the GitHub Actions cache — which is exactly what #385 intended, just with this scary log line along the way. All jobs on the first post-merge run (including `pypy-3.11`) passed.

## Fix

Explicitly set `use-flakehub: false` and `use-gha-cache: true` so the action relies solely on the GitHub Actions cache, with no FlakeHub round-trip and no misleading error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)