### PR TITLE
Always roll back failed bulk updates, not just when on_dup can raise

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,19 @@ please consider sponsoring bidict on GitHub.`
   rather than failing clean.
   :issue:`389`
 
+- Fix a bug where a bulk update did not fail clean at all
+  when the :class:`~bidict.OnDup` in effect contained no
+  :attr:`~bidict.RAISE` action –
+  as with :meth:`~bidict.MutableBidict.forceupdate`,
+  :meth:`~bidict.MutableBidict.putall` passed :attr:`~bidict.ON_DUP_DROP_OLD`,
+  or :meth:`~bidict.MutableBidict.update` on a subclass
+  that overrides :attr:`~bidict.BidictBase.on_dup`
+  (e.g. the ``YoloBidict`` recipe in :doc:`extending`).
+  Rollback was previously enabled only when a duplication error was possible,
+  but a bulk update can also fail while unpacking an item,
+  hashing a key or value, or writing to a backing mapping.
+  Rollback is now always enabled for these methods.
+
 
 0.23.1 (2024-02-18)
 -------------------

--- a/bidict/_base.py
+++ b/bidict/_base.py
@@ -422,10 +422,17 @@ class BidictBase(BidirectionalMapping[KT, VT]):
         arg: MapOrItems[KT, VT],
         kw: Mapping[str, VT] = MappingProxyType({}),
         *,
-        rollback: bool | None = None,
+        rollback: bool = True,
         on_dup: OnDup | None = None,
     ) -> None:
-        """Update with the items from *arg* and *kw*, maybe failing and rolling back as per *on_dup* and *rollback*."""
+        """Update with the items from *arg* and *kw*, failing clean as per *rollback*.
+
+        When *rollback* is true (the default), a failure part-way through leaves self
+        exactly as it was before the update was attempted.
+
+        Callers pass rollback=False only when self is a throwaway instance that is
+        discarded if the update fails, and so has nothing to roll back to.
+        """
         # Note: We must process input in a single pass, since arg may be a generator.
         if not isinstance(arg, (Iterable, Maplike)):
             raise TypeError(f"'{arg.__class__.__name__}' object is not iterable")
@@ -433,8 +440,6 @@ class BidictBase(BidirectionalMapping[KT, VT]):
             return
         if on_dup is None:
             on_dup = self.on_dup
-        if rollback is None:
-            rollback = RAISE in on_dup
 
         # Fast path when we're empty and updating only from another bidict (i.e. no dup vals in new items).
         if not self and not kw and isinstance(arg, BidictBase):

--- a/tests/bidict_test_fixtures.py
+++ b/tests/bidict_test_fixtures.py
@@ -270,3 +270,10 @@ class HashRaises:
 
 
 bomb = HashRaises()
+
+BAD_ITEMS = (
+    (RuntimeError, (bomb, 0)),  # hashing the key raises
+    (RuntimeError, (0, bomb)),  # hashing the value raises
+    (TypeError, (['unhashable'], 0)),
+    (ValueError, (1, 2, 'bad len')),
+)

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -30,6 +30,7 @@ from typing import assert_type
 from unittest.mock import ANY
 
 import pytest
+from bidict_test_fixtures import BAD_ITEMS
 from bidict_test_fixtures import BB
 from bidict_test_fixtures import BT
 from bidict_test_fixtures import KT
@@ -87,6 +88,9 @@ keys = sampled_from(ks)
 vals = sampled_from(vs)
 items = sampled_from(list(powerset(product(ks, vs))))
 items121 = items.map(dedup)
+# Items that can never duplicate anything in a bidict under test: their keys and values are
+# disjoint from ks and vs, and they are 1:1 among themselves.
+fresh_items = sampled_from(list(powerset((k, -k) for k in range(5, 9))))
 bidict_t = sampled_from(bidict_types)
 mut_bidict_t = sampled_from(mutable_bidict_types)
 updates_t = sampled_from(update_arg_types)
@@ -198,6 +202,15 @@ class BidictStateMachine(RuleBasedStateMachine):
             partial(self.bi.putall, updates_t(updates), on_dup),
             partial(self.oracle.putall, updates_t(updates), on_dup),
         )
+
+    @rule(new=fresh_items, on_dup=on_dup)
+    def putall_with_bad_item(self, new: Items, on_dup: OnDup) -> None:
+        """A bulk update whose last item raises must apply none of it, whatever the on_dup.
+
+        The preceding items are fresh, so the only thing that can fail is the bad item.
+        Pass an iterator so this always takes the incremental rollback path.
+        """
+        assert_update_fails_clean(self.bi, iter([*new, (bomb, 0)]), RuntimeError, on_dup)
 
     @rule(other=items121)
     def __ior__(self, other: Mapping[int, int]) -> None:
@@ -422,16 +435,28 @@ def assert_putall_matches_bulk_put(bi: MutableBidict[int, int], new_items: Items
     assert bi.inv == tmp.inv
 
 
-def assert_update_fails_clean(bi: MutableBidict[t.Any, t.Any], updates: t.Any, exc_t: type[Exception]) -> None:
+def assert_update_fails_clean(
+    bi: MutableBidict[t.Any, t.Any],
+    updates: t.Any,
+    exc_t: type[Exception],
+    on_dup: OnDup | None = None,
+) -> None:
+    """Check that a bulk update that raises *exc_t* leaves *bi* exactly as it was.
+
+    Exercises update() (i.e. bi's own on_dup) when *on_dup* is None, else putall().
+    """
     before = bi.copy()
+    do_update = partial(bi.update, updates) if on_dup is None else partial(bi.putall, updates, on_dup)
     with pytest.raises(exc_t):
-        bi.update(updates)
+        do_update()
     assert bi.equals_order_sensitive(before)
     assert bi.inv.equals_order_sensitive(before.inv)
 
 
-@pytest.mark.parametrize('bi_t', mutable_bidict_types)
-def test_update_with_bad_last_item_fails_clean(bi_t: MBT[t.Any, t.Any]) -> None:
+# A RAISE-free on_dup must fail clean too: a bulk update can raise for reasons that have
+# nothing to do with duplication, so rollback cannot be conditioned on on_dup.
+@pytest.mark.parametrize(('bi_t', 'on_dup'), list(product(mutable_bidict_types, (None, *on_dups))))
+def test_update_with_bad_last_item_fails_clean(bi_t: MBT[t.Any, t.Any], on_dup: OnDup | None) -> None:
     # Keep self at least as large as updates so this sized arg takes the
     # in-place rollback path rather than the copy fast path.
     bi = bi_t({
@@ -440,14 +465,11 @@ def test_update_with_bad_last_item_fails_clean(bi_t: MBT[t.Any, t.Any]) -> None:
         2: 2,
     })
     for b in (bi, bi.inv):
-        for exc, bad in (
-            (RuntimeError, (bomb, 0)),
-            (RuntimeError, (0, bomb)),
-            (TypeError, (['unhashable'], 0)),
-            (ValueError, (1, 2, 'bad len')),
-        ):
+        for exc, bad in BAD_ITEMS:
+            # The items before the bad one are all new, so the update fails for the
+            # bad item's reason regardless of the on_dup.
             updates = [(3, 3), (4, 4), bad]
-            assert_update_fails_clean(b, updates, exc)
+            assert_update_fails_clean(b, updates, exc, on_dup)
 
 
 def test_pickle_orderedbi_whose_order_disagrees_with_fwdm() -> None:


### PR DESCRIPTION
Completes the fix started in #389.

## The bug

`_update()` derived whether to roll back from the `OnDup` in effect:

```python
rollback = RAISE in on_dup
```

But `on_dup` only governs *duplication* failures. A bulk update can also fail while
unpacking an item, hashing a key or value, or writing to a backing mapping — and those
failures are possible no matter what `on_dup` says. So a RAISE-free `OnDup` disabled
rollback entirely:

```python
>>> class HashRaises:
...     def __hash__(self): raise RuntimeError('boom!')
>>> bomb = HashRaises()

>>> b = bidict({0: 0, 1: 1, 2: 2})
>>> b.forceupdate([(3, 3), (4, 4), (bomb, 5)])
RuntimeError: boom!
>>> b
bidict({0: 0, 1: 1, 2: 2, 3: 3, 4: 4})   # <- first two items stuck
```

Affected: `forceupdate()`, `putall()` passed `ON_DUP_DROP_OLD` (or any other RAISE-free
`OnDup`), and `update()` on a subclass that overrides `on_dup` — including the
`YoloBidict` recipe in `docs/extending.rst`.

#389 widened the unwind to catch any exception, but only *within* the rollback-enabled
path, so this half went unfixed.

This contradicts the guarantee documented under
[Updates Fail Clean](https://bidict.readthedocs.io/en/main/basic-usage.html#updates-fail-clean),
whose "Order Matters" section lists `forceupdate()` among the bulk operations carrying
"the extremely important advantage of failing clean".

## The fix

`rollback` becomes a plain `bool = True`. The four internal callers that build a
throwaway instance, and so have nothing to roll back to — `__init__`, the copy fast
path, `__or__` and `__ror__` — already pass `rollback=False` explicitly and are
unaffected.

## Cost

Rollback bookkeeping now runs on paths that previously skipped it. Measured with an
in-process A/B of two copies of the package, min-of-11:

| | delta |
|---|---|
| `forceput`, value-dup overwrite | +6.7 – 7.5% |
| `forceput`, new item | +5.9 – 6.9% |
| `forceupdate`, 3 real overwrites | +12% |
| `__setitem__` (control — already rolled back) | +0.6% |
| `bi[0]` (calibration) | −0.4% |

Note the repo's `microbenchmarks.py` cases are single-round `pedantic` runs, so they
report `StdDev 0.0` and can't be used for before/after comparison directly.

## Tests

- `test_update_with_bad_last_item_fails_clean` is now parametrized over `on_dup` as
  well, so it covers `putall()` with every `OnDup` alongside the existing `update()`
  case. Against the unfixed code, 20 of its 50 parametrizations fail.
- `BidictStateMachine` gains a `putall_with_bad_item` rule: it appends a bad item to a
  run of *fresh* items — drawn from key/value domains disjoint from `ks`/`vs`, and 1:1
  among themselves, so they cannot duplicate anything already present — and asserts via
  the existing `assert_update_fails_clean` helper that the bidict is left exactly as it
  was, order included.
- The malformed items moved into a shared `BAD_ITEMS` fixture.

Because Hypothesis is nondeterministic, the new rule's power was measured rather than
assumed: run as independent trials against the reintroduced bug with a fresh in-memory
example database each time, it detects it in **25/25** trials at
`max_examples=100 × 50 steps`, and 21/25 at a deliberately starved `25 × 10`. It finds
nothing against the fixed code (0/25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
