### PR TITLE
Propagate the benchmarked command's exit status from cachegrind.py

### DIFF
--- a/cachegrind.py
+++ b/cachegrind.py
@@ -48,16 +48,20 @@ ARCH = sp.check_output(['uname', '-m'], text=True).strip()
 DISABLE_ASLR_CMD = ['setarch', ARCH, '-R']
 
 
-def run_with_cachegrind(args_list: list[str]) -> dict[str, int]:
+def run_with_cachegrind(args_list: list[str]) -> tuple[int, dict[str, int]]:
     """
     Run the the given program and arguments under Cachegrind, parse the
     Cachegrind specs.
 
+    Return the program's exit status along with the parsed results.
+
     For now we just ignore program output, and in general this is not robust.
     """
     temp_file = NamedTemporaryFile('r+')  # noqa: SIM115
-    # Don't fail if the program fails (to support e.g. `pytest --benchmark-compare-fail=...`)
-    sp.call([
+    # Don't raise if the program fails (to support e.g. `pytest --benchmark-compare-fail=...`),
+    # but do return its status so that main() can exit with it. Callers such as the benchmark
+    # workflow rely on it to tell a benchmark regression from a clean run.
+    returncode = sp.call([
         *DISABLE_ASLR_CMD,
         'valgrind',
         '--tool=cachegrind',
@@ -71,7 +75,7 @@ def run_with_cachegrind(args_list: list[str]) -> dict[str, int]:
         '--cachegrind-out-file=' + temp_file.name,
         *args_list,
     ])
-    return parse_cachegrind_output(temp_file)
+    return returncode, parse_cachegrind_output(temp_file)
 
 
 def parse_cachegrind_output(temp_file: t.IO[str]) -> dict[str, int]:
@@ -128,10 +132,11 @@ def combined_instruction_estimate(counts: dict[str, int]) -> int:
 
 
 def main() -> None:
-    results = run_with_cachegrind(sys.argv[1:])
+    returncode, results = run_with_cachegrind(sys.argv[1:])
     counts = get_counts(results)
     estimate = combined_instruction_estimate(counts)
     print(f'{"*" * 80}\nCombined instruction estimate: {estimate:,}')  # noqa: T201
+    sys.exit(returncode)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The benchmark workflow decides what to report from the exit status of the command it wraps:

```bash
benchmark_status=${PIPESTATUS[0]}
if [ "$benchmark_status" -eq 0 ]; then
  result_state=ok
  result_message='no threshold-triggering regressions detected'
elif grep -Fq 'Performance has regressed:' benchmark-output.txt; then
  result_state=regression
```

That status comes from `cachegrind.py`, which always exits 0 — so the `elif` is unreachable and every run reports "no threshold-triggering regressions detected".

**#393 is a live example.** pytest raised `PerformanceRegression` and logged four benchmarks over the threshold ([job log](https://github.com/jab/bidict/actions/runs/32662405874/job/97250469121?pr=393)):

```
Performance has regressed:
	test_bi_inverse_getitem_present[1000-str] - Field 'min' has failed PercentageRegressionCheck: 43.93 > 5.0
	test_bi_iter[100]                         - Field 'min' has failed PercentageRegressionCheck:  6.22 > 5.0
	test_bi_equals_with_equal_dict[100]       - Field 'min' has failed PercentageRegressionCheck:  9.86 > 5.0
	test_orderedbi_items_equals_with_equal_dict_items[1000] - ...        6.99 > 5.0
```

and [the PR comment](https://github.com/jab/bidict/pull/393#issuecomment-5388125335) still said none were detected.

## Cause

`run_with_cachegrind()` deliberately uses `sp.call()` rather than `sp.check_call()`, so the Cachegrind output file still gets parsed when the benchmarked command fails — which is what makes `--benchmark-compare-fail` usable at all. But it then discarded the status:

```python
# Don't fail if the program fails (to support e.g. `pytest --benchmark-compare-fail=...`)
sp.call([...])                          # <- return value dropped
return parse_cachegrind_output(temp_file)

def main() -> None:
    results = run_with_cachegrind(sys.argv[1:])
    ...                                 # <- no sys.exit()
```

So it defeated the very thing the `sp.call()` was there to enable.

## Fix

Return the status alongside the parsed results, and exit with it. The grep pattern in the workflow is already correct — pytest-benchmark logs the colon form at `session.py:244` before raising — it just never ran.

No workflow change is needed: it already handles a nonzero status, warning and staying green for PRs since benchmarking is informational there.

## Verification

Locally (valgrind isn't available on darwin, so the probe and subprocess call are stubbed): a wrapped command exiting 0/1/3 now makes `cachegrind.py` exit 0/1/3 respectively. Before, all three exited 0.

The benchmark run on this PR should now report honestly. Note it will compare against the current baseline asset, which dates from 2026-07-06 — before the 12 commits that have since touched `bidict/` — so whatever it reports is the cumulative delta since then, not the effect of any one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
