### PR TITLE
Keep one object per item across a bidict and its inverse

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,16 @@ please consider sponsoring bidict on GitHub.`
   hashing a key or value, or writing to a backing mapping.
   Rollback is now always enabled for these methods.
 
+- A bidict and its inverse now always refer to the same object
+  for each contained key and value,
+  rather than possibly to equivalent but distinct ones,
+  so that e.g. ``b.inverse[b[key]] is key`` always holds.
+  Writing an item whose key or value is equal to a contained one
+  now keeps the object already contained,
+  as :class:`dict` does when a key is overwritten,
+  instead of keeping one object in each direction.
+  *See also* :ref:`addendum:Equivalent but distinct \:class\:\`~collections.abc.Hashable\`\\s`
+
 - Fix a bug where mutating an :class:`~bidict.OrderedBidict`
   while iterating over it produced incorrect behavior
   rather than raising an error.

--- a/bidict/_base.py
+++ b/bidict/_base.py
@@ -456,6 +456,16 @@ class BidictBase(BidirectionalMapping[KT, VT]):
         fwdm, invm = self._fwdm, self._invm
         fwdm_set, invm_set = fwdm.__setitem__, invm.__setitem__
         fwdm_del, invm_del = fwdm.__delitem__, invm.__delitem__
+        # When newkey or newval duplicates one already contained, adopt the object already
+        # contained rather than the one passed in. Otherwise the two backing mappings would end
+        # up referring to equal but distinct objects for the same item, since a dict keeps the
+        # key object it already has when a key is overwritten but takes the new value object.
+        # invm[oldval] is the contained key equal to newkey; fwdm[oldkey] the contained value
+        # equal to newval. This also matches what a plain dict does on overwrite.
+        if oldval is not MISSING:  # newkey duplicates a contained key
+            newkey = invm[oldval]
+        if oldkey is not MISSING:  # newval duplicates a contained value
+            newval = fwdm[oldkey]
         # Always perform the following writes regardless of duplication.
         fwdm_set(newkey, newval)
         invm_set(newval, newkey)

--- a/docs/addendum.rst
+++ b/docs/addendum.rst
@@ -168,19 +168,27 @@ even if it is distinct.
 
 With a :class:`~bidict.bidict`,
 since values function as keys in the inverse mapping,
-this behavior occurs in the inverse direction too,
-and means that a :class:`~bidict.bidict` can end up with a different
-but equivalent key from the corresponding value
-in its own inverse:
+this behavior occurs in the inverse direction too.
+
+That puts a :class:`~bidict.bidict` between two of :class:`dict`'s conventions,
+which conflict once a value is also a key:
+overwriting a :class:`dict` key keeps the key object already contained,
+but replaces the value object with the one passed in.
+A :class:`~bidict.bidict` resolves this
+by keeping the object already contained in both directions,
+so that a single item is never represented by
+two equivalent but distinct objects:
 
 .. doctest::
 
    >>> b = bidict({'false': 0})
    >>> b.forceput('FALSE', False)
-   >>> b
-   bidict({'FALSE': False})
+   >>> b  # the contained 0 is kept, rather than the equivalent False passed in
+   bidict({'FALSE': 0})
    >>> b.inverse
    bidict({0: 'FALSE'})
+   >>> b.inverse[b['FALSE']] is next(iter(b))  # one object per item, in both directions
+   True
 
 
 *nan* as a Key

--- a/tests/bidict_test_fixtures.py
+++ b/tests/bidict_test_fixtures.py
@@ -291,6 +291,26 @@ def dedup(x: MapOrItems[KT, VT]) -> dict[KT, VT]:
     return invdict(invdict(dict(x)))
 
 
+@dataclass(frozen=True)
+class Tagged:
+    """Equal whenever *n* is equal, but each instance is distinguishable by its *tag*.
+
+    Stands in for the realistic case of value-equal objects that carry distinct state,
+    e.g. a dataclass whose __eq__ covers only some of its fields.
+    """
+
+    n: int
+    tag: str = ''
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Tagged) and self.n == other.n
+
+    @override
+    def __hash__(self) -> int:
+        return hash(self.n)
+
+
 class HashRaises:
     @override
     def __hash__(self) -> int:

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -40,6 +40,7 @@ from bidict_test_fixtures import SET_OPS
 from bidict_test_fixtures import VT
 from bidict_test_fixtures import Oracle
 from bidict_test_fixtures import SupportsKeysAndGetItem
+from bidict_test_fixtures import Tagged
 from bidict_test_fixtures import UserBi
 from bidict_test_fixtures import UserBiBackedByDictSub
 from bidict_test_fixtures import UserBiNotOwnInv
@@ -849,6 +850,57 @@ def test_orderedbidict_iteration_unaffected_by_unrelated_bidict() -> None:
         other[key] = f'x{key}'  # a different bidict, so a different linked list
         keys.append(key)
     assert keys == [1, 2]
+
+
+#: (label, mutation) pairs, each writing an item that duplicates a contained key, a contained
+#: value, or both, using an object that is equal to the contained one but not identical to it.
+_DUPLICATING_WRITES: t.Any = {
+    'key_duplication': lambda b: b.__setitem__(Tagged(1, 'new'), 'other'),
+    'value_duplication': lambda b: b.forceput(Tagged(9, 'new'), Tagged(2, 'new')),
+    'collapse': lambda b: b.forceput(Tagged(1, 'new'), Tagged(2, 'new')),
+}
+
+
+@pytest.mark.parametrize('mutate', _DUPLICATING_WRITES.values(), ids=list(_DUPLICATING_WRITES))
+@pytest.mark.parametrize('bi_t', mutable_bidict_types)
+def test_one_object_per_item_in_both_directions(bi_t: MBT[t.Any, t.Any], mutate: t.Any) -> None:
+    """A bidict and its inverse must hold the same object for each item, not equal copies.
+
+    dict keeps the key object it already has when a key is overwritten, but takes the new
+    value object. In a bidict a value is also a key of the inverse, so those two conventions
+    conflict; applying each to its own backing mapping left the two holding equal but distinct
+    objects for one item, and so left b.inverse[b[key]] not identical to key.
+    """
+    bi = bi_t({Tagged(1, 'orig'): Tagged(2, 'orig')})
+    mutate(bi)
+    for key in bi:
+        val = bi[key]
+        assert bi.inverse[val] is key, 'key differs between a bidict and its inverse'
+        inv_key = next(k for k in bi.inverse if k == val)
+        assert inv_key is val, 'value differs between a bidict and its inverse'
+
+
+@pytest.mark.parametrize('bi_t', mutable_bidict_types)
+def test_duplicating_write_keeps_the_contained_object(bi_t: MBT[t.Any, t.Any]) -> None:
+    """Of two equal objects, the one already contained is the one kept.
+
+    That is what a dict does for keys, and it is the only self-consistent choice here:
+    adopting the incoming key object instead would mean deleting and reinserting it, which
+    would move the item to the end and so silently reorder the bidict.
+    """
+    bi = bi_t({Tagged(1, 'orig'): Tagged(2, 'orig')})
+    bi[Tagged(1, 'new')] = Tagged(3, 'new')  # key duplicates the contained Tagged(1)
+    (key,) = bi
+    assert key.tag == 'orig'
+    assert bi.inverse[bi[key]].tag == 'orig'
+
+
+@pytest.mark.parametrize('bi_t', mutable_bidict_types)
+def test_duplicating_write_does_not_reorder(bi_t: MBT[t.Any, t.Any]) -> None:
+    """Keeping the contained key object also keeps the item in place."""
+    bi = bi_t({Tagged(1): 'one', Tagged(2): 'two'})
+    bi[Tagged(1, 'new')] = 'uno'
+    assert [k.n for k in bi] == [1, 2]
 
 
 def test_orderedbidict_weakattr_class_access() -> None:


### PR DESCRIPTION
## The bug

Writing an item whose key or value equals a contained one could leave the two backing mappings holding equivalent but *distinct* objects for that item:

```python
>>> b = bidict({1: 'a'})
>>> b[True] = 'b'        # True == 1, so this overwrites the contained item
>>> next(iter(b))
1                        # int
>>> b.inverse['b']
True                     # bool -- equal, but not the same object
```

So `b.inverse[b[key]] is key` did not hold. It bites hardest with value-equal objects carrying distinct state — a dataclass whose `__eq__` covers only some fields:

```
fwd key tag='first'   inv value tag='second'   same object: False
```

Which instance a caller gets depends on which direction they look it up from.

## Cause

A bidict sits between two of `dict`'s conventions, which conflict once a value is also a key:

- overwriting a `dict` **key** keeps the key object already contained
- ...but replaces the **value** object with the one passed in

`_write` applied each convention to its own backing mapping — locally right, jointly incoherent.

## Fix

Resolve in favor of the object already contained, in both directions. On a duplicating write, adopt `invm[oldval]` as the key and/or `fwdm[oldkey]` as the value before writing.

The alternative — letting the incoming object win — isn't viable: replacing a contained *key* object requires delete-then-reinsert, which would move the item to the end and **silently reorder the bidict**. There's a test pinning that.

`OrderedBidict` needs no change: `_assoc_node` goes through `forceput`, i.e. this same code, so its node map ends up holding the contained object too. Verified explicitly, including the `bykey=False` path via the inverse.

## Cost

Only the duplicating branches do extra lookups; a write with no duplication pays two pointer comparisons.

| write path | before | after | |
|---|---|---|---|
| setitem, new item (no duplication) | 9364n | 9485n | +1.3% |
| setitem, key duplication | 19375n | 19515n | +0.7% |
| forceput, value duplication | 19400n | 19497n | +0.5% |
| forceput, collapse | 29198n | 29447n | +0.9% |

## ⚠️ Documented behavior change

`docs/addendum.rst` documented the old behavior with a doctest, which this changes:

```python
>>> b = bidict({'false': 0})
>>> b.forceput('FALSE', False)
>>> b
bidict({'FALSE': False})     # before
bidict({'FALSE': 0})         # after -- the contained 0 is kept
```

The passage presented this as a consequence of how dicts treat equivalent but distinct keys. It's rewritten to explain the conflict between dict's two conventions and how a bidict resolves it, and now also asserts the invariant that motivated the change.

## Tests

30 new cases across all mutable bidict types × the three duplication branches (key, value, collapse), plus the reordering guard. **16 of 30 fail against `main`**; the reordering ones pass either way by design, since they guard against the rejected alternative.

Green: 283 tests (default and `more-examples`), `ty`, all prek hooks, docs with `-W -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
