### PR TITLE
Cut the runtime typing overhead from every bidict update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -105,15 +105,23 @@ please consider sponsoring bidict on GitHub.`
   :issue:`376`
 
 - Speed up every bidict update.
-  :func:`typing.cast` has no effect at runtime,
-  but Python still evaluates the type expression passed to it,
-  and subscripting a :mod:`typing` alias is expensive.
-  Casts now pass their type expressions as strings,
-  which type checkers still understand
-  but Python never evaluates.
   Single-item writes such as
-  :meth:`~bidict.MutableBidict.__setitem__`
-  are ~1.6x faster as a result.
+  :meth:`~bidict.MutableBidict.__setitem__`,
+  :meth:`~bidict.MutableBidict.put`, and
+  :meth:`~bidict.MutableBidict.forceput`
+  are now ~3.6x faster,
+  and bulk updates are faster too.
+  Two sources of per-call overhead were removed
+  from the item iteration that every update goes through:
+  a :func:`typing.cast` whose type expression
+  Python was evaluating on every call
+  (casts now pass their type expressions as strings,
+  which type checkers still understand
+  but Python never evaluates),
+  and an :func:`isinstance` check against a
+  :func:`~typing.runtime_checkable` :class:`~typing.Protocol`,
+  which is expensive when it fails
+  and was failing for the most common case.
 
 - A bidict backed by a :class:`dict` *subclass*
   now gets that mapping's own views from

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -104,6 +104,17 @@ please consider sponsoring bidict on GitHub.`
   rather than behaving like the equivalent plain :class:`dict` views.
   :issue:`376`
 
+- Speed up every bidict update.
+  :func:`typing.cast` has no effect at runtime,
+  but Python still evaluates the type expression passed to it,
+  and subscripting a :mod:`typing` alias is expensive.
+  Casts now pass their type expressions as strings,
+  which type checkers still understand
+  but Python never evaluates.
+  Single-item writes such as
+  :meth:`~bidict.MutableBidict.__setitem__`
+  are ~1.6x faster as a result.
+
 - A bidict backed by a :class:`dict` *subclass*
   now gets that mapping's own views from
   :meth:`~bidict.BidictBase.keys` and :meth:`~bidict.BidictBase.items`,

--- a/bidict/_base.py
+++ b/bidict/_base.py
@@ -228,7 +228,7 @@ class BidictBase(BidirectionalMapping[KT, VT]):
         # be pickled at all, since nothing else refers to it by name. __name__ is left alone, so
         # repr() is unaffected.
         inv_cls.__qualname__ = f'{cls.__qualname__}._inv_cls'
-        return t.cast(type[t.Self], inv_cls)
+        return t.cast('type[t.Self]', inv_cls)
 
     @classmethod
     def _inv_cls_dict_diff(cls) -> dict[str, t.Any]:

--- a/bidict/_iter.py
+++ b/bidict/_iter.py
@@ -24,7 +24,11 @@ def iteritems(arg: MapOrItems[KT, VT] = (), /, **kw: VT) -> ItemsIter[KT, VT]:
     """Yield the items from *arg* and *kw* in the order given."""
     if isinstance(arg, Mapping):
         yield from t.cast('Mapping[KT, VT]', arg).items()
-    elif isinstance(arg, Maplike):
+    # isinstance() against a runtime-checkable Protocol is cheap when it succeeds but expensive
+    # when it fails: it falls back to inspect.getattr_static() per member and caches nothing.
+    # It fails for an iterable of items, which is what every single-item write passes, so screen
+    # that case out first -- a Maplike has a keys attribute by definition.
+    elif hasattr(arg, 'keys') and isinstance(arg, Maplike):
         yield from ((key, arg[key]) for key in arg.keys())
     else:
         yield from arg

--- a/bidict/_iter.py
+++ b/bidict/_iter.py
@@ -23,12 +23,12 @@ from ._typing import MapOrItems
 def iteritems(arg: MapOrItems[KT, VT] = (), /, **kw: VT) -> ItemsIter[KT, VT]:
     """Yield the items from *arg* and *kw* in the order given."""
     if isinstance(arg, Mapping):
-        yield from t.cast(Mapping[KT, VT], arg).items()
+        yield from t.cast('Mapping[KT, VT]', arg).items()
     elif isinstance(arg, Maplike):
         yield from ((key, arg[key]) for key in arg.keys())
     else:
         yield from arg
-    yield from t.cast(ItemsIter[KT, VT], kw.items())
+    yield from t.cast('ItemsIter[KT, VT]', kw.items())
 
 
 swap: t.Final = itemgetter(1, 0)

--- a/bidict/_orderedbase.py
+++ b/bidict/_orderedbase.py
@@ -194,7 +194,7 @@ class OrderedBidictBase(BidictBase[KT, VT]):
 
     @override
     def _make_inverse(self) -> OrderedBidictBase[VT, KT]:
-        inv = t.cast(OrderedBidictBase[VT, KT], super()._make_inverse())
+        inv = t.cast('OrderedBidictBase[VT, KT]', super()._make_inverse())
         inv._sntl = self._sntl
         inv._node_by_korv = self._node_by_korv
         inv._bykey = not self._bykey
@@ -318,7 +318,7 @@ class OrderedBidictBase(BidictBase[KT, VT]):
         # _fwdm to yield values in key order (see BidictBase.values()), an ordered bidict
         # gets that for free: the inverse shares this bidict's linked list, so its keys
         # view already yields the values in this bidict's order.
-        return t.cast(BidictKeysView[VT], self.inverse.keys())
+        return t.cast('BidictKeysView[VT]', self.inverse.keys())
 
 
 # The following MappingView implementations use the __iter__ implementations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ extend-select = [
   "SLOT",
   "T20",
   "T100",
+  "TC006",
   "TID",
   "UP",
   "W",

--- a/tests/bidict_test_fixtures.py
+++ b/tests/bidict_test_fixtures.py
@@ -46,7 +46,7 @@ VT = t.TypeVar('VT')
 class SupportsKeysAndGetItem(t.Generic[KT, VT]):
     def __init__(self, *args: t.Any, **kw: t.Any) -> None:
         # This fixture trusts its *args/**kw (typed Any); dict(**kw) yields str keys, so cast to the declared type.
-        self._mapping = t.cast(Mapping[KT, VT], dict(*args, **kw))
+        self._mapping = t.cast('Mapping[KT, VT]', dict(*args, **kw))
 
     def keys(self) -> KeysView[KT]:
         return self._mapping.keys()
@@ -240,7 +240,7 @@ class Oracle(t.Generic[KT, VT]):
         tmp = self.data.copy()
         items: Iterable[tuple[KT, VT]]
         if isinstance(updates, Mapping):
-            items = t.cast(Mapping[KT, VT], updates).items()
+            items = t.cast('Mapping[KT, VT]', updates).items()
         elif isinstance(updates, Maplike):
             items = [(key, updates[key]) for key in updates.keys()]
         else:

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -1033,7 +1033,7 @@ def test_values_view_reversibility_matches_bidict(bi_t: BT[t.Any, t.Any]) -> Non
     else:
         assert not isinstance(values, Reversible)
         with pytest.raises(TypeError):  # and the claim is not a lie
-            reversed(t.cast(t.Any, values))
+            reversed(t.cast('t.Any', values))
 
 
 @pytest.mark.parametrize('bi_t', bidict_types)


### PR DESCRIPTION
A single-item write cost ~11 µs, against ~26 ns for a lookup on the same bidict.
Almost all of that was typing machinery being re-evaluated on every call,
in code that every update passes through.

Two independent causes, each worth about half. One commit for each.

## 1. `cast()` evaluates its type expression

`typing.cast()` has no effect at runtime — it returns its second argument unchanged.
But Python still evaluates the type expression passed as its first,
and that is not always cheap:

```python
ItemsIter[KT, VT]    3300 ns   # Iterator[tuple[KT, VT]], a typing alias
Mapping[KT, VT]        97 ns   # a class, via C-level types.GenericAlias
```

Subscripting a *class* is fine; re-subscripting a *typing alias* is not,
because substituting the type variables happens in Python rather than in C.

`iteritems()` paid the expensive one on every call regardless of which branch it took,
since the cast covering `**kw` runs unconditionally.
Of the 8.5 µs that `bi[k] = v` took, 3.4 µs went into building a type expression
that nothing subsequently looked at.

Passing the expression as a string fixes it —
type checkers read string type expressions, Python never evaluates them.
Half the casts in the codebase already did this,
so this also makes the style uniform.
[ruff's `TC006`](https://docs.astral.sh/ruff/rules/runtime-cast-value/) is enabled
to keep it that way; it found three more in the tests.

## 2. A failing protocol check is expensive

`isinstance()` against a `runtime_checkable` Protocol is not symmetric in cost:

```python
isinstance(SupportsKeysAndGetItem(), Maplike)     184 ns   # succeeds
isinstance([(1, 2)], Maplike)                    3142 ns   # fails
```

`_ProtocolMeta.__instancecheck__` consults the ABC cache first,
and on a miss falls back to `inspect.getattr_static()` for each protocol member.
Unlike an ABC it caches nothing when the answer is no,
so the same class pays in full on every call.

`iteritems()` reaches that check for anything that is not a `Mapping` —
which is exactly where the answer is usually no, an iterable of items.
`put()` passes `((key, val),)`, so every `__setitem__`, `put`, and `forceput` paid it.

Screening with `hasattr()` first keeps that off the common path
while leaving `Maplike` as the authority on what qualifies:
a `Maplike` has a `keys` attribute by definition,
so an object without one cannot satisfy the protocol,
and one with it still has to pass the real check.

## Results

Median over the setitem and forceput microbenchmarks: **1.6× from the first commit, 3.6× from both.**

| benchmark | main | +casts | +protocol |
|---|---|---|---|
| `setitem_new_item[100]` | 11.33 µs | 6.88 µs | **2.83 µs** |
| `setitem_new_item[10000]` | 11.71 µs | 7.46 µs | **3.00 µs** |
| `setitem_replace_existing_key[10000]` | 15.04 µs | 7.12 µs | **3.00 µs** |
| `forceput_existing_value[1000]` | 10.21 µs | 7.37 µs | **2.83 µs** |
| `update_partial_overlap[1000]` | 630.8 µs | | **453.5 µs** |
| `unpickle[100]` | 17.53 µs | | **12.92 µs** |

`OrderedBidictBase.values()`, which paid a smaller version of the first cost,
goes from 313 ns to 217 ns. Lookups are unchanged at 26 ns.

Across all 69 microbenchmarks the median change is −2.3%,
with three showing +8–19%: all sub-microsecond,
all in code these changes cannot reach (`pop`, `__getitem__`),
and all flipping sign across sizes.

## Behavior

Old and new dispatch were diffed over 32 combinations of argument and keyword types,
including objects with `keys` but no `__getitem__`, `keys` only via `__getattr__`,
`keys` set to `None`, and `keys` alongside `__iter__`.
Exactly one differs: an object whose `keys` is a property that raises `AttributeError`,
which `getattr_static()` sees and `hasattr()` does not.

## Verification

An AST scan for typing constructs in executable positions
(subscripted generics inside function bodies, `get_type_hints`/`get_args`/`get_origin`,
protocol `isinstance` sites, unquoted `cast()` arguments)
reports 5 hits against `main` and 0 here,
and confirms every module has `from __future__ import annotations`
so that no annotation is ever evaluated.

Both commits are independently green:
303 tests, `ty`, all prek hooks, and docs with `-W -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
