### PR TITLE
Write a single item without the bulk update machinery

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -109,19 +109,23 @@ please consider sponsoring bidict on GitHub.`
   :meth:`~bidict.MutableBidict.__setitem__`,
   :meth:`~bidict.MutableBidict.put`, and
   :meth:`~bidict.MutableBidict.forceput`
-  are now ~3.6x faster,
+  are now ~8x faster,
   and bulk updates are faster too.
-  Two sources of per-call overhead were removed
-  from the item iteration that every update goes through:
-  a :func:`typing.cast` whose type expression
+  Most of what a single-item write cost
+  was never the write:
+  it was a :func:`typing.cast` whose type expression
   Python was evaluating on every call
   (casts now pass their type expressions as strings,
   which type checkers still understand
   but Python never evaluates),
-  and an :func:`isinstance` check against a
+  an :func:`isinstance` check against a
   :func:`~typing.runtime_checkable` :class:`~typing.Protocol`,
   which is expensive when it fails
-  and was failing for the most common case.
+  and was failing for the most common case,
+  and the argument handling and bulk fast paths
+  of the general update machinery,
+  which a single item was being routed through
+  but could never benefit from.
 
 - A bidict backed by a :class:`dict` *subclass*
   now gets that mapping's own views from

--- a/bidict/_base.py
+++ b/bidict/_base.py
@@ -26,6 +26,7 @@ from collections.abc import Mapping
 from collections.abc import MutableMapping
 from collections.abc import Reversible
 from collections.abc import Set
+from collections.abc import Sized
 from collections.abc import ValuesView
 from operator import eq
 from types import MappingProxyType
@@ -543,7 +544,7 @@ class BidictBase(BidirectionalMapping[KT, VT]):
 
         # Fast path when we're adding more items than we contain already and rollback is enabled:
         # Update a copy of self with rollback disabled. Fail if that fails, otherwise become the copy.
-        if rollback and isinstance(arg, t.Sized) and len(arg) + len(kw) > len(self):
+        if rollback and isinstance(arg, Sized) and len(arg) + len(kw) > len(self):
             tmp = self.copy()
             tmp._update(arg, kw, rollback=False, on_dup=on_dup)
             self._init_from(tmp)

--- a/bidict/_bidict.py
+++ b/bidict/_bidict.py
@@ -21,6 +21,7 @@ from collections.abc import Mapping
 
 from ._abc import MutableBidirectionalMapping
 from ._base import BidictBase
+from ._base import Unwrites
 from ._dup import ON_DUP_DROP_OLD
 from ._dup import ON_DUP_RAISE
 from ._dup import OnDup
@@ -109,7 +110,20 @@ class MutableBidict(BidictBase[KT, VT], MutableBidirectionalMapping[KT, VT]):
             duplicates another existing item's, and *on_dup.val* is
             :attr:`~bidict.RAISE`.
         """
-        self._update(((key, val),), on_dup=on_dup)
+        # Rather than self._update(((key, val),), on_dup=on_dup): a single item needs none of
+        # the argument-type dispatch, iteration, or bulk fast paths that _update() provides, and
+        # they cost several times what writing the item does. Rollback is still required, since
+        # OrderedBidictBase._write() can fail after the write it delegates to has succeeded.
+        dedup_result = self._dedup(key, val, on_dup)
+        if dedup_result is None:
+            return
+        unwrites: Unwrites = []
+        try:
+            self._write(key, val, *dedup_result, unwrites=unwrites)
+        except Exception:
+            for fn, *args in reversed(unwrites):
+                fn(*args)
+            raise
 
     def forceput(self, key: KT, val: VT) -> None:
         """Associate *key* with *val* unconditionally.


### PR DESCRIPTION
Follow-on to #399, which cut the typing overhead out of the update path.
What remained was that a single-item write was still being routed
through machinery built for bulk updates.

## `typing.Sized` is not `collections.abc.Sized`

It is a `_SpecialGenericAlias` wrapping it,
and `isinstance()` against it has to unwrap to the origin first:

```python
isinstance(arg, typing.Sized)            250 ns
isinstance(arg, collections.abc.Sized)   111 ns
```

`_update()` runs that check on every update.
`typing.Sized` has also been deprecated in favor of `collections.abc.Sized`
since Python 3.9 (PEP 585); ruff's `UP035` does not flag this one
because it is reached as an attribute of the `typing` module
rather than imported from it.

## A single item does not need the bulk update machinery

`put()` — and so `__setitem__()` and `forceput()`, which delegate to it —
built a one-item tuple and handed it to `_update()`:

```
isinstance(arg, (Iterable, Maplike))     132 ns
isinstance(arg, Sized), len comparison   172 ns
iteritems(arg) generator, for one item   467 ns
---------------------------------------------
                                        ~770 ns
_dedup(), which does the actual work      94 ns
```

Worse, `_update()`'s bulk fast path fires
whenever the argument holds more items than `self`,
which for a one-item argument means whenever `self` is empty.
The first insertion into an empty bidict therefore
copied `self`, recursed into `_update()` on the copy, and rebuilt from it:
**5969 ns to write one item, against 796 ns now.**

`put()` now calls `_dedup()` and `_write()` directly.
Rollback is kept rather than dropped as an obvious saving,
because `OrderedBidictBase._write()` extends the unwrites
that the `BidictBase._write()` it delegates to has already recorded,
and can fail after that inherited write has succeeded.

## Results

| benchmark | before #399 | after #399 | here | total |
|---|---|---|---|---|
| `setitem_new_item[1000]` | 10.87 µs | 2.67 µs | **1.08 µs** | 10.0× |
| `setitem_new_item[10000]` | 11.71 µs | 3.00 µs | **1.21 µs** | 9.7× |
| `setitem_replace_existing_key[1000]` | 11.08 µs | 3.17 µs | **1.46 µs** | 7.6× |
| `forceput_existing_value[1000]` | 10.21 µs | 2.83 µs | **1.21 µs** | 8.5× |

Median **2.3× on top of #399**, and **7.6× overall**.

Note when reading the CI benchmark comment that its wall-clock check
is noise-dominated on GHA runners:
running the same build twice locally gives a spread of
median 1.5%, p90 11.1%, max 24.9%,
against its `min:10%` threshold.
The instruction count is the metric to read.

## Behavior

Unchanged. Both commits are independently green:
303 tests, `ty`, all prek hooks, and docs with `-W -n`.

`put()`'s failure behavior was compared against `_update()`'s
for both `bidict` and `OrderedBidict`,
including the case where a custom backing mapping raises mid-write,
and is identical.
(That case is not currently fail-clean, for either implementation —
tracked separately, it predates this PR and #399.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
