### PR TITLE
Undo the writes already applied when a later one is refused

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,6 +75,12 @@ please consider sponsoring bidict on GitHub.`
   Rollback is now always enabled for these methods.
   :issue:`392`
 
+- Fix a bug where a write that a custom backing mapping refused
+  could leave a custom bidict's two backing mappings out of sync,
+  breaking the bidirectional invariant,
+  rather than failing clean.
+  :issue:`401`
+
 - Fix a bug where mutating an :class:`~bidict.OrderedBidict`
   while iterating over it produced incorrect behavior
   rather than raising an error.

--- a/bidict/_base.py
+++ b/bidict/_base.py
@@ -472,46 +472,28 @@ class BidictBase(BidirectionalMapping[KT, VT]):
             newkey = invm[oldval]
         if oldkey is not MISSING:  # newval duplicates a contained value
             newval = fwdm[oldkey]
-        # Always perform the following writes regardless of duplication.
+        # Record each unwrite as soon as its write succeeds, rather than all of them at the end:
+        # a backing mapping is user-supplied (see _fwdm_cls/_invm_cls) and may reject a write, and
+        # if it does, everything written before it still has to be undone. Note that the four
+        # writes below touch four distinct slots, so the order they are undone in does not matter.
         fwdm_set(newkey, newval)
+        if unwrites is not None:
+            # {0: 1} | {2: 3} => del fwdm[2];  {0: 1} | {0: 3} => fwdm[0] = 1
+            unwrites.append((fwdm_del, newkey) if oldval is MISSING else (fwdm_set, newkey, oldval))
         invm_set(newval, newkey)
-        if oldval is MISSING and oldkey is MISSING:  # no key or value duplication
-            # {0: 1, 2: 3} | {4: 5} => {0: 1, 2: 3, 4: 5}
-            if unwrites is not None:
-                unwrites.extend((
-                    (fwdm_del, newkey),
-                    (invm_del, newval),
-                ))
-        elif oldval is not MISSING and oldkey is not MISSING:  # key and value duplication across two different items
-            # {0: 1, 2: 3} | {0: 3} => {0: 3}
-            fwdm_del(oldkey)
-            invm_del(oldval)
-            if unwrites is not None:
-                unwrites.extend((
-                    (fwdm_set, newkey, oldval),
-                    (invm_set, oldval, newkey),
-                    (fwdm_set, oldkey, newval),
-                    (invm_set, newval, oldkey),
-                ))
-        elif oldval is not MISSING:  # just key duplication
-            # {0: 1, 2: 3} | {2: 4} => {0: 1, 2: 4}
-            invm_del(oldval)
-            if unwrites is not None:
-                unwrites.extend((
-                    (fwdm_set, newkey, oldval),
-                    (invm_set, oldval, newkey),
-                    (invm_del, newval),
-                ))
-        else:
-            assert oldkey is not MISSING  # just value duplication
+        if unwrites is not None:
+            # {0: 1} | {2: 3} => del invm[3];  {0: 1} | {2: 1} => invm[1] = 0
+            unwrites.append((invm_del, newval) if oldkey is MISSING else (invm_set, newval, oldkey))
+        if oldkey is not MISSING:  # newval duplicates the value of the item keyed by oldkey
             # {0: 1, 2: 3} | {4: 3} => {0: 1, 4: 3}
             fwdm_del(oldkey)
             if unwrites is not None:
-                unwrites.extend((
-                    (fwdm_set, oldkey, newval),
-                    (invm_set, newval, oldkey),
-                    (fwdm_del, newkey),
-                ))
+                unwrites.append((fwdm_set, oldkey, newval))
+        if oldval is not MISSING:  # newkey duplicates the key of the item valued by oldval
+            # {0: 1, 2: 3} | {2: 4} => {0: 1, 2: 4}
+            invm_del(oldval)
+            if unwrites is not None:
+                unwrites.append((invm_set, oldval, newkey))
 
     def _update(
         self,

--- a/tests/bidict_test_fixtures.py
+++ b/tests/bidict_test_fixtures.py
@@ -330,3 +330,40 @@ BAD_ITEMS = (
     (TypeError, (['unhashable'], 0)),
     (ValueError, (1, 2, 'bad len')),
 )
+
+
+class WriteRefused(Exception):
+    """Raised by the backing mappings that :func:`bidict_refusing_nth_write` provides."""
+
+
+def bidict_refusing_nth_write(bi_t: BT[t.Any, t.Any], init: Mapping[t.Any, t.Any], n: int) -> BB[t.Any, t.Any]:
+    """Return a *bi_t* containing *init* whose nth write from now on raises :class:`WriteRefused`.
+
+    Stands in for a custom bidict's backing mapping that may raise on a write it will not accept,
+    e.g. SortedDict's TypeError when a key is not orderable with the keys already contained.
+
+    Both backing mappings are given the same class, so the count spans them
+    the way a single _write() does.
+    """
+    counting = False
+    counter = iter(range(1, 1000))
+
+    def tick() -> None:
+        if counting and next(counter) == n:
+            raise WriteRefused
+
+    class RefusingDict(UserDict[t.Any, t.Any]):
+        @override
+        def __setitem__(self, key: t.Any, item: t.Any) -> None:
+            tick()
+            super().__setitem__(key, item)
+
+        @override
+        def __delitem__(self, key: t.Any) -> None:
+            tick()
+            super().__delitem__(key)
+
+    bi_t_refusing = type(f'Refusing{bi_t.__name__}', (bi_t,), {'_fwdm_cls': RefusingDict, '_invm_cls': RefusingDict})
+    bi = bi_t_refusing(init)
+    counting = True  # writing init above must not count
+    return bi

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -47,9 +47,12 @@ from bidict_test_fixtures import UserBiBackedByDictSub
 from bidict_test_fixtures import UserBiNotOwnInv
 from bidict_test_fixtures import UserOrderedBi
 from bidict_test_fixtures import UserOrderedBiBase
+from bidict_test_fixtures import WriteRefused
+from bidict_test_fixtures import bidict_refusing_nth_write
 from bidict_test_fixtures import bidict_types
 from bidict_test_fixtures import bomb
 from bidict_test_fixtures import dedup
+from bidict_test_fixtures import invdict
 from bidict_test_fixtures import mutable_bidict_types
 from bidict_test_fixtures import pickle_copy
 from bidict_test_fixtures import powerset
@@ -537,6 +540,43 @@ def test_update_with_bad_last_item_fails_clean(bi_t: MBT[t.Any, t.Any], on_dup: 
             # bad item's reason regardless of the on_dup.
             updates = [(3, 3), (4, 4), bad]
             assert_update_fails_clean(b, updates, exc, on_dup)
+
+
+@pytest.mark.parametrize('bi_t', [bidict, OrderedBidict])
+@pytest.mark.parametrize(
+    ('init', 'write', 'nwrites'),
+    [
+        # One case per kind of duplication BidictBase._write() handles, with the number of writes
+        # to the backing mappings it performs: two to insert the new item, plus one to remove each
+        # item that the new one displaces.
+        ({1: 'a'}, lambda b: b.__setitem__(2, 'b'), 2),
+        ({1: 'a'}, lambda b: b.__setitem__(1, 'z'), 3),
+        ({1: 'a'}, lambda b: b.forceput(9, 'a'), 3),
+        ({1: 'a', 2: 'b'}, lambda b: b.forceput(1, 'b'), 4),
+    ],
+    ids=['no-dup', 'dup-key', 'dup-val', 'dup-key-and-val'],
+)
+def test_write_fails_clean_when_a_backing_mapping_refuses(
+    bi_t: MBT[t.Any, t.Any], init: dict[t.Any, t.Any], write: t.Any, nwrites: int
+) -> None:
+    """Writing one item must fail clean when a backing mapping refuses part-way through.
+
+    _write() sets both backing mappings, and for some kinds of duplication deletes from them too.
+    Backing mappings are user-supplied (see _fwdm_cls and _invm_cls), so any one of those writes
+    can be refused, and everything already written must then be undone.
+    """
+    unchanged = dict(init), invdict(init)
+    refused = 0
+    for n in range(1, nwrites + 2):  # one past the last, which must find nothing left to refuse
+        bi = bidict_refusing_nth_write(bi_t, init, n)
+        try:
+            write(bi)
+        except WriteRefused:
+            refused += 1
+            assert (dict(bi._fwdm), dict(bi._invm)) == unchanged, f'refusing write #{n} left bi changed'
+        else:
+            break
+    assert refused == nwrites
 
 
 @pytest.mark.parametrize('bi_t', mutable_bidict_types)


### PR DESCRIPTION
A write that a backing mapping refused part-way through
left a bidict with its two backing mappings out of sync,
breaking the bidirectional invariant rather than failing clean.

Using the `SortedBidict` recipe from `docs/extending.rst` verbatim:

```python
>>> b = SortedBidict({'Tokyo': 'Japan', 'Cairo': 'Egypt'})
>>> b['Lima'] = 42
TypeError: '<' not supported between instances of 'int' and 'str'
>>> len(b), b['Lima'], 42 in b.inverse
(3, 42, False)
```

`'Lima'` sorts among the contained keys, so writing it to `_fwdm` succeeds.
`42` does not sort among the contained values, so writing it to `_invm` raises.
The first write stays applied.

## Cause

`_write()` performed all of its writes to the backing mappings
and only then recorded the operations needed to undo them,
so when one raised, `_update()`'s rollback had nothing to work with.

Everything after the *first* write was exposed.
Refusing the nth write of each kind, on `main`:

| | write 1 | write 2 | write 3 | write 4 |
|---|---|---|---|---|
| no duplication | clean | **broken** | | |
| duplicate key | clean | **broken** | **broken** | |
| duplicate value | clean | **broken** | dirty | |
| duplicate key and value | clean | **broken** | **broken** | **broken** |

("broken" = `_fwdm` and `_invm` disagree; "dirty" = changed but self-consistent.)

## Fix

Each unwrite is recorded as soon as its write succeeds.

That also lets the four duplication cases collapse into two conditionals,
since what undoes each write depends only on
whether `oldval`/`oldkey` is `MISSING` —
a net **18 fewer lines** in `_write()`.

## Scope

Only bidicts with custom backing mappings can reach this
(see `_fwdm_cls` and `_invm_cls`):
a plain `dict` does not refuse a write whose key it has already hashed.
Real backing mappings do refuse writes, though —
`SortedDict` when a key is not orderable with those already contained,
`WeakValueDictionary` when a value cannot be weakly referenced.

Bulk updates large enough to take the copy fast path were also unaffected,
since that works on a throwaway and discards it on failure.

## Tests

`test_write_fails_clean_when_a_backing_mapping_refuses`
refuses the nth write for each n in turn,
for every kind of duplication `_write()` handles,
and checks the bidict is left exactly as it was.
8 cases (4 kinds × `bidict`/`OrderedBidict`); **all 8 fail without the fix.**

Performance is unchanged: median −0.1% across all 69 microbenchmarks.

Green: 311 tests, `ty`, all prek hooks, and docs with `-W -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
