### PR TITLE
Undo the removal already applied when the other one is refused

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,11 +75,12 @@ please consider sponsoring bidict on GitHub.`
   Rollback is now always enabled for these methods.
   :issue:`392`
 
-- Fix a bug where a write that a custom backing mapping refused
+- Fix a bug where a write or removal that a custom backing mapping refused
   could leave a custom bidict's two backing mappings out of sync,
   breaking the bidirectional invariant,
   rather than failing clean.
   :issue:`401`
+  :issue:`403`
 
 - Fix a bug where mutating an :class:`~bidict.OrderedBidict`
   while iterating over it produced incorrect behavior

--- a/bidict/_bidict.py
+++ b/bidict/_bidict.py
@@ -48,8 +48,20 @@ class MutableBidict(BidictBase[KT, VT], MutableBidirectionalMapping[KT, VT]):
         def inv(self) -> MutableBidict[VT, KT]: ...
 
     def _pop(self, key: KT) -> VT:
-        val = self._fwdm.pop(key)
-        del self._invm[val]
+        return self._pop_invm(key, self._fwdm.pop(key))
+
+    def _pop_invm(self, key: KT, val: VT) -> VT:
+        """Remove *val* from _invm, *key* having already been removed from _fwdm.
+
+        Puts (key, val) back if _invm refuses the removal, so that a backing mapping
+        rejecting one half of a removal cannot leave the two disagreeing. This is the
+        removing counterpart of the unwrites that :meth:`BidictBase._write` records.
+        """
+        try:
+            del self._invm[val]
+        except Exception:
+            self._fwdm[key] = val
+            raise
         return val
 
     @override
@@ -167,8 +179,7 @@ class MutableBidict(BidictBase[KT, VT], MutableBidirectionalMapping[KT, VT]):
         :raises KeyError: if *x* is empty.
         """
         key, val = self._fwdm.popitem()
-        del self._invm[val]
-        return key, val
+        return key, self._pop_invm(key, val)
 
     @override
     def update(self, arg: MapOrItems[KT, VT] = (), /, **kw: VT) -> None:

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -579,6 +579,40 @@ def test_write_fails_clean_when_a_backing_mapping_refuses(
     assert refused == nwrites
 
 
+@pytest.mark.parametrize('bi_t', [bidict, OrderedBidict])
+@pytest.mark.parametrize(
+    ('remove', 'nwrites'),
+    [
+        # Removing an item takes two writes whichever way it is asked for: one to each
+        # backing mapping.
+        (lambda b: b.__delitem__(1), 2),
+        (lambda b: b.pop(1), 2),
+        (lambda b: b.popitem(), 2),
+    ],
+    ids=['delitem', 'pop', 'popitem'],
+)
+def test_remove_fails_clean_when_a_backing_mapping_refuses(bi_t: MBT[t.Any, t.Any], remove: t.Any, nwrites: int) -> None:
+    """Removing an item must fail clean when a backing mapping refuses part-way through.
+
+    The removing counterpart of test_write_fails_clean_when_a_backing_mapping_refuses:
+    removing from one backing mapping and then being refused by the other must not leave
+    the two disagreeing.
+    """
+    init = {1: 'a', 2: 'b'}
+    unchanged = dict(init), invdict(init)
+    refused = 0
+    for n in range(1, nwrites + 2):  # one past the last, which must find nothing left to refuse
+        bi = bidict_refusing_nth_write(bi_t, init, n)
+        try:
+            remove(bi)
+        except WriteRefused:
+            refused += 1
+            assert (dict(bi._fwdm), dict(bi._invm)) == unchanged, f'refusing write #{n} left bi changed'
+        else:
+            break
+    assert refused == nwrites
+
+
 @pytest.mark.parametrize('bi_t', mutable_bidict_types)
 @pytest.mark.parametrize('roundtrip', [copy, deepcopy, pickle_copy], ids=['copy', 'deepcopy', 'pickle'])
 def test_roundtrip_preserves_iteration_order(bi_t: MBT[t.Any, t.Any], roundtrip: t.Any) -> None:


### PR DESCRIPTION
#401 fixed a refused *write* leaving the two backing mappings out of sync.
The mirror image was still in place: removing an item also takes
one write to each backing mapping, and the second was unprotected.

```python
def _pop(self, key):
    val = self._fwdm.pop(key)   # succeeds
    del self._invm[val]         # refused -> _fwdm has already lost the item
    return val
```

`popitem()` had the same shape, and `__delitem__()`, `pop()`,
and `OrderedBidict.popitem()` all reach one or the other,
so every way of removing an item could leave the two mappings disagreeing —
breaking the bidirectional invariant rather than failing clean.

Refusing each of the two writes in turn, on `main`:

| | write 1 | write 2 |
|---|---|---|
| `del b[k]` | clean | **BROKEN** |
| `b.pop(k)` | clean | **BROKEN** |
| `b.popitem()` | clean | **BROKEN** |

(Identical for `bidict` and `OrderedBidict`.) Clean throughout after this.

## Fix

Both call sites go through `_pop_invm()`, which puts the item back
if the second removal raises.

`OrderedBidict._pop()` composes correctly with that:
it dissociates the node only after the inherited `_pop()` returns,
so a refusal leaves the linked list untouched and its own order intact.

## `clear()` is deliberately left alone

It has the same shape — `_fwdm.clear()` then `_invm.clear()` —
but making it atomic would mean buffering the whole contents first,
and "clear failed part-way" is a much weaker thing to promise
than "the two directions agree".

## Reachability

Lower than the refused write. That one could be triggered through the
`SortedBidict` recipe in `docs/extending.rst`, because `SortedDict` refuses to
insert a key it cannot order — but removing a key it already holds does not
fail. This needs a backing mapping that rejects removals for its own reasons.
It is fixed anyway because the asymmetry would be surprising: anyone reading
`_write()`'s comment about undoing partial writes would reasonably assume
removals got the same treatment.

## Tests

`test_remove_fails_clean_when_a_backing_mapping_refuses`, the counterpart of the
write test added in #401, reusing the same `bidict_refusing_nth_write` fixture.
6 cases (`del`/`pop`/`popitem` × `bidict`/`OrderedBidict`); **all 6 fail without
the fix.**

Green: 317 tests, `ty`, all prek hooks, and docs with `-W -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
