### PR TITLE
Update the lint hooks, and select and ignore ruff rules by name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,31 +27,31 @@ repos:
       - id: remove-tabs
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         args: ["--uri-ignore-words-list", "*"]  # https://github.com/codespell-project/codespell/issues/2473
 
   - repo: https://github.com/adhtruong/mirrors-typos
-    rev: v1.48.0
+    rev: v1.49.0
     hooks:
       - id: typos
         args: [--write-changes]
 
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.72
+    rev: v0.0.74
     hooks:
       - id: ty
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.16.4
     hooks:
       - id: ruff-check
         args: [--fix, --unsafe-fixes]
       - id: ruff-format
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
+    rev: v0.11.0.1-1
     hooks:
       - id: shellcheck
         exclude: ^.envrc$

--- a/cachegrind.py
+++ b/cachegrind.py
@@ -59,7 +59,7 @@ def run_with_cachegrind(args_list: list[str]) -> tuple[int, dict[str, int]]:
 
     For now we just ignore program output, and in general this is not robust.
     """
-    temp_file = NamedTemporaryFile('r+')  # noqa: SIM115
+    temp_file = NamedTemporaryFile('r+')  # ruff: ignore[open-file-with-context-handler]
     # Don't raise if the program fails (to support e.g. `pytest --benchmark-compare-fail=...`),
     # but do return its status so that main() can exit with it. Callers such as the benchmark
     # workflow rely on it to tell a benchmark regression from a clean run.
@@ -137,7 +137,7 @@ def main() -> None:
     returncode, results = run_with_cachegrind(sys.argv[1:])
     counts = get_counts(results)
     estimate = combined_instruction_estimate(counts)
-    print(f'{"*" * 80}\nCombined instruction estimate: {estimate:,}')  # noqa: T201
+    print(f'{"*" * 80}\nCombined instruction estimate: {estimate:,}')  # ruff: ignore[print]
     # Unlike the wall-clock figures pytest-benchmark records, which vary with whatever else is
     # running on the machine, this estimate counts instructions and so is reproducible. Write it
     # out when asked, so a caller can compare it between revisions without a noise allowance.

--- a/cachegrind.py
+++ b/cachegrind.py
@@ -59,7 +59,7 @@ def run_with_cachegrind(args_list: list[str]) -> tuple[int, dict[str, int]]:
 
     For now we just ignore program output, and in general this is not robust.
     """
-    temp_file = NamedTemporaryFile('r+')  # ruff: ignore[open-file-with-context-handler]
+    temp_file = NamedTemporaryFile('r+', encoding='utf-8')  # ruff: ignore[open-file-with-context-handler]
     # Don't raise if the program fails (to support e.g. `pytest --benchmark-compare-fail=...`),
     # but do return its status so that main() can exit with it. Callers such as the benchmark
     # workflow rely on it to tell a benchmark regression from a clean run.
@@ -137,13 +137,13 @@ def main() -> None:
     returncode, results = run_with_cachegrind(sys.argv[1:])
     counts = get_counts(results)
     estimate = combined_instruction_estimate(counts)
-    print(f'{"*" * 80}\nCombined instruction estimate: {estimate:,}')  # ruff: ignore[print]
+    print(f'{"*" * 80}\nCombined instruction estimate: {estimate:,}')
     # Unlike the wall-clock figures pytest-benchmark records, which vary with whatever else is
     # running on the machine, this estimate counts instructions and so is reproducible. Write it
     # out when asked, so a caller can compare it between revisions without a noise allowance.
     estimate_out = os.environ.get('CACHEGRIND_ESTIMATE_OUT')
     if estimate_out:
-        Path(estimate_out).write_text(f'{estimate}\n')
+        Path(estimate_out).write_text(f'{estimate}\n', encoding='utf-8')
     sys.exit(returncode)
 
 

--- a/cachegrind.py
+++ b/cachegrind.py
@@ -59,6 +59,8 @@ def run_with_cachegrind(args_list: list[str]) -> tuple[int, dict[str, int]]:
 
     For now we just ignore program output, and in general this is not robust.
     """
+    # Deliberately not a context manager: this stays open across the run below, which writes to
+    # it, and is read afterwards.
     temp_file = NamedTemporaryFile('r+', encoding='utf-8')  # ruff: ignore[open-file-with-context-handler]
     # Don't raise if the program fails (to support e.g. `pytest --benchmark-compare-fail=...`),
     # but do return its status so that main() can exit with it. Callers such as the benchmark

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
     'sphinx.ext.viewcode',
 ]
 try:
-    import sphinx_copybutton  # noqa: F401
+    import sphinx_copybutton  # ruff: ignore[unused-import]
 except ImportError:
     pass
 else:
@@ -66,7 +66,7 @@ project = bidict_metadata['Name']
 # Extract author name from "Name <email>" format
 author_email = bidict_metadata['Author-email']
 author = author_email.split('<')[0].strip() if author_email else 'Joshua Bronson'
-copyright = f'2009-2026 {author}'  # noqa: A001
+copyright = f'2009-2026 {author}'  # ruff: ignore[builtin-variable-shadowing]
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ project = bidict_metadata['Name']
 # Extract author name from "Name <email>" format
 author_email = bidict_metadata['Author-email']
 author = author_email.split('<')[0].strip() if author_email else 'Joshua Bronson'
-copyright = f'2009-2026 {author}'
+copyright = f'2009-2026 {author}'  # ruff: ignore[builtin-variable-shadowing]
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@
 
 """Sphinx configuration."""
 
+import importlib.util
 from importlib.metadata import metadata
 
 
@@ -40,11 +41,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
 ]
-try:
-    import sphinx_copybutton  # ruff: ignore[unused-import]
-except ImportError:
-    pass
-else:
+if importlib.util.find_spec('sphinx_copybutton'):
     extensions.append('sphinx_copybutton')
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
@@ -66,7 +63,7 @@ project = bidict_metadata['Name']
 # Extract author name from "Name <email>" format
 author_email = bidict_metadata['Author-email']
 author = author_email.split('<')[0].strip() if author_email else 'Joshua Bronson'
-copyright = f'2009-2026 {author}'  # ruff: ignore[builtin-variable-shadowing]
+copyright = f'2009-2026 {author}'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ project = bidict_metadata['Name']
 # Extract author name from "Name <email>" format
 author_email = bidict_metadata['Author-email']
 author = author_email.split('<')[0].strip() if author_email else 'Joshua Bronson'
-copyright = f'2009-2026 {author}'  # ruff: ignore[builtin-variable-shadowing]
+copyright = f'2009-2026 {author}'  # ruff: ignore[builtin-variable-shadowing]  # Sphinx requires this name
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,10 @@ missing-override-decorator = "error"  # require @override on overriding methods
 [tool.ruff]
 preview = true
 line-length = 121
+# Ruff's default rule set grows between minor versions, so an older ruff than the one pinned in
+# .pre-commit-config.yaml lints with fewer rules and passes code that CI rejects. Fail on that
+# rather than let it be discovered in CI. ./update_dev_dependencies checks these two stay in step.
+required-version = ">=0.16.4"
 
 [tool.ruff.lint]
 # https://docs.astral.sh/ruff/rules/
@@ -136,8 +140,7 @@ typing-modules = ["bidict._typing"]
 
 # Suppressions that are properties of a whole file rather than of one line in it.
 [tool.ruff.lint.per-file-ignores]
-"cachegrind.py" = ["print"]                      # printing its results is what this script is for
-"docs/conf.py" = ["builtin-variable-shadowing"]  # Sphinx requires the copyright variable be named that
+"cachegrind.py" = ["print"]  # printing its results is what this script is for
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,9 +121,10 @@ extend-select = [
   "UP",
   "W",
   "YTT",
-  # Individual rules:
+  # Individual rules, from linters whose other rules do not suit this codebase:
   "debugger",
-  "runtime-cast-value",  # keeps cast()'s type expression from being evaluated at runtime
+  "runtime-cast-value",   # keeps cast()'s type expression from being evaluated at runtime
+  "unspecified-encoding",  # text I/O should not depend on the machine's locale
 ]
 ignore = [
   "in-dict-keys",                          # https://github.com/astral-sh/ruff/issues/4481
@@ -132,6 +133,11 @@ ignore = [
   "useless-import-alias",                  # Allow explicit re-exports (import X as X)
 ]
 typing-modules = ["bidict._typing"]
+
+# Suppressions that are properties of a whole file rather than of one line in it.
+[tool.ruff.lint.per-file-ignores]
+"cachegrind.py" = ["print"]                      # printing its results is what this script is for
+"docs/conf.py" = ["builtin-variable-shadowing"]  # Sphinx requires the copyright variable be named that
 
 [tool.ruff.lint.isort]
 force-single-line = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,9 +136,9 @@ ignore = [
   "unaliased-collections-abc-set-import",  # Prefer `Set` over `AbstractSet` for readability
   "useless-import-alias",                  # Allow explicit re-exports (import X as X)
 ]
+# Rules that know about typing should treat what bidict._typing re-exports the same way.
 typing-modules = ["bidict._typing"]
 
-# Suppressions that are properties of a whole file rather than of one line in it.
 [tool.ruff.lint.per-file-ignores]
 "cachegrind.py" = ["print"]  # printing its results is what this script is for
 
@@ -150,7 +150,7 @@ lines-after-imports = 2
 docstring-code-format = true
 docstring-code-line-length = "dynamic"
 preview = true
-quote-style = "single"
+quote-style = "single"  # Keep the code (especially in the docs' doctests) matching Python's output
 
 [tool.pytest]
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,8 @@ line-length = 121
 
 [tool.ruff.lint]
 # https://docs.astral.sh/ruff/rules/
+# Whole linters, selected by prefix. Individual rules are selected by name below, since
+# a name says what it checks where a code does not.
 extend-select = [
   "A",
   "ARG",
@@ -115,18 +117,19 @@ extend-select = [
   "RUF",
   "SLOT",
   "T20",
-  "T100",
-  "TC006",
   "TID",
   "UP",
   "W",
   "YTT",
+  # Individual rules:
+  "debugger",
+  "runtime-cast-value",  # keeps cast()'s type expression from being evaluated at runtime
 ]
 ignore = [
-  "PLC0414", # Allow explicit re-exports (import X as X)
-  "PYI025",  # Prefer `Set` over `AbstractSet` for readability
-  "RUF067",  # Allow __init__.py to set __module__ on re-exported classes
-  "SIM118",  # https://github.com/astral-sh/ruff/issues/4481
+  "in-dict-keys",                          # https://github.com/astral-sh/ruff/issues/4481
+  "non-empty-init-module",                 # Allow __init__.py to set __module__ on re-exported classes
+  "unaliased-collections-abc-set-import",  # Prefer `Set` over `AbstractSet` for readability
+  "useless-import-alias",                  # Allow explicit re-exports (import X as X)
 ]
 typing-modules = ["bidict._typing"]
 

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -715,7 +715,7 @@ def test_bimap_bad_inverse() -> None:
 
     bi = BimapBadInverse()
     with pytest.raises(NotImplementedError):
-        bi.inverse  # ruff: ignore[useless-expression]
+        bi.inverse  # ruff: ignore[useless-expression]  # evaluating it is the point: it must raise
 
 
 skip_if_pypy = pytest.mark.skipif(

--- a/tests/test_bidict.py
+++ b/tests/test_bidict.py
@@ -715,7 +715,7 @@ def test_bimap_bad_inverse() -> None:
 
     bi = BimapBadInverse()
     with pytest.raises(NotImplementedError):
-        bi.inverse  # noqa: B018
+        bi.inverse  # ruff: ignore[useless-expression]
 
 
 skip_if_pypy = pytest.mark.skipif(
@@ -1215,7 +1215,7 @@ def assert_calls_match(call1: Callable[..., t.Any], call2: Callable[..., t.Any])
     for call in results:
         try:
             results[call] = call()
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:  # ruff: ignore[blind-except]
             results[call] = exc.__class__
     assert results[call1] == results[call2]
 

--- a/update_dev_dependencies
+++ b/update_dev_dependencies
@@ -13,6 +13,27 @@ log() {
 }
 
 
+# prek auto-update moves the ruff pin in .pre-commit-config.yaml but knows nothing about
+# pyproject.toml's required-version, which exists to reject a local ruff older than that pin.
+# Left to drift, the floor keeps passing versions that lint with fewer rules than CI uses.
+check_ruff_required_version() {
+  local pinned required
+  pinned=$(grep -A1 'astral-sh/ruff-pre-commit' .pre-commit-config.yaml | sed -n 's/^ *rev: v//p')
+  required=$(sed -n 's/^required-version = ">=\(.*\)"$/\1/p' pyproject.toml)
+  if [[ -z $pinned || -z $required ]]; then
+    log "Warning: could not compare ruff's pinned version to pyproject.toml's required-version."
+    log "         Check by hand that they agree, and fix this check if its parsing has gone stale."
+    return
+  fi
+  if [[ $pinned != "$required" ]]; then
+    log "Action needed: ruff is pinned to v$pinned, but required-version says >=$required."
+    log "               Set required-version = \">=$pinned\" in pyproject.toml, so that a ruff"
+    log "               older than the pinned one fails instead of linting with fewer rules."
+    log
+  fi
+}
+
+
 main() {
   declare -r hint="Hint: Use 'nix develop' to bootstrap a development environment"
 
@@ -31,6 +52,7 @@ main() {
   prek auto-update
   log "Upgrading pre-commit hooks: Done"
   log
+  check_ruff_required_version
   log "Reminders:"
   log " - Check release notes of upgraded packages for anything that affects bidict."
   log " - Ensure tests pass for all supported Python versions."


### PR DESCRIPTION
Three commits: the hook updates, an audit of what the config actually says, and a pin
that keeps a stale local ruff from linting differently than CI.

## 1. Update the lint hooks (`6da30c7`)

| hook | | |
|---|---|---|
| ruff | v0.15.20 | **v0.16.4** |
| ty | v0.0.72 | v0.0.74 |
| typos | v1.48.0 | v1.49.0 |
| codespell | v2.4.2 | v2.4.3 |
| shellcheck | v0.11.0.1 | v0.11.0.1-1 |

Two preview rules ruff 0.16 adds are about how the linter itself is addressed, and this
repo runs `preview = true`, so both applied.

**`RUF201`** wants rule names over codes. Worth taking for the individual rules — a code
says nothing about what it checks — but its autofix leaves `extend-select` mixing names
with the linter prefixes that have no name form, unsorted. Split into prefixes first, then
individual rules. Both renamed selectors were checked to still fire, by reintroducing an
unquoted `cast()` and a `pdb.set_trace()`; a selector that silently matched nothing would
look exactly like a clean run.

**`RUF105`** wants `# ruff: ignore[name]` over `# noqa: CODE`. Verified line-scoped, not
file-scoped, before accepting — the hook applies this automatically under `--unsafe-fixes`,
so a rewrite that quietly widened every suppression to its whole file would have been easy
to miss.

## 2. Audit the suppressions and the rule set (`71d068c`)

Taking each suppression at the scope it belongs at halves them, 6 to 3:

| | |
|---|---|
| `unused-import` on `import sphinx_copybutton` | **code changed** — it existed only to test availability, so `importlib.util.find_spec` says what is meant and needs no suppression |
| `print` in `cachegrind.py` | **per-file** — printing its results is what the script is for, so any future print there is legitimate too |
| `builtin-variable-shadowing`, `blind-except`, `useless-expression`, `open-file-with-context-handler` | **stay inline** — each is the only instance in its file, so inline keeps the locality without silencing the rule for future code |

Surveying every rule ruff has gives 925 findings, nearly all of them objecting to choices
this codebase has already made deliberately: 421 want double quotes it does not use, 165
flag `assert`s it means, 40 flag `Any`s it means.

One was real. **`cachegrind.py` read and wrote text in the locale's encoding**, which is
neither what the data is nor stable across machines, and PEP 686 changes the default in
3.15. Both sites now say `utf-8`, and `unspecified-encoding` is enabled so it cannot return.

Enabling whole linters instead of these single rules does not pay: flake8-debugger contains
only `debugger`; all of flake8-type-checking adds `TC003` ×2, wanting `TYPE_CHECKING` blocks
for two imports; and the rest of Pylint-W wants `bidict`/`frozenbidict` renamed to CapWords
and `__hash__` on `BidictBase`, which is deliberately absent.

## 3. Pin a ruff floor, and keep it honest (`f79ee83`)

Ruff's *default* rule set grew between 0.15 and 0.16, and `extend-select` builds on it — so
the running version decides what gets checked. An older local ruff lints with fewer rules,
looks clean, and fails in CI. `required-version` makes that immediate instead:

```
ruff failed
  Cause: Required version `>=0.16.4` does not match the running version `0.15.20`
```

That introduces a second pin to keep in step, and `prek auto-update` moves only the first.
So `update_dev_dependencies`, which runs it, now compares them:

```
> Action needed: ruff is pinned to v0.17.1, but required-version says >=0.16.4.
>                Set required-version = ">=0.17.1" in pyproject.toml, so that a ruff
>                older than the pinned one fails instead of linting with fewer rules.
```

Reported rather than fatal: a stale floor still rejects a much older ruff, so forgetting
weakens the check without breaking anything. Silent when they agree, and warns rather than
passing quietly if it cannot parse either file — stale parsing would otherwise be
indistinguishable from agreement. All three paths were exercised.

Green: `ruff check .` (config included), all prek hooks, `ty`, 317 tests, docs with `-W -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
